### PR TITLE
Converted Visual Studio include paths to relative paths.

### DIFF
--- a/xpcPlugin/xpcPlugin/xpcPlugin/xpcPlugin.vcxproj
+++ b/xpcPlugin/xpcPlugin/xpcPlugin/xpcPlugin.vcxproj
@@ -93,7 +93,7 @@
       <PreprocessorDefinitions>IBM=1;XPLM200;_DEBUG;_WINDOWS;_USRDLL;XPCPLUGIN_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>
       </SDLCheck>
-      <AdditionalIncludeDirectories>./src;\\vmware-host\Shared Folders\Documents\xplaneconnect\xpcPlugin\SDK\CHeaders\XPLM;\\vmware-host\Shared Folders\Documents\xplaneconnect\xpcPlugin;\\vmware-host\Shared Folders\Documents\xplaneconnect\C\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>./src;../../SDK/CHeaders/XPLM;../../;../../../C/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <OmitFramePointers />


### PR DESCRIPTION
- Include paths were specified with absolute paths, which break as soon as the project is moved to a different location. (e.g., when cloning to a new computer from GitHub).
- Include paths are now specified relative to the project file, so everything should work as long as the entire XPC directory is present.
