### PR TITLE
Several small fixes

### DIFF
--- a/C/xpcExample/xpcExample.win/xpcExample.sln
+++ b/C/xpcExample/xpcExample.win/xpcExample.sln
@@ -1,0 +1,19 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "xpcExample", "xpcExample.vcxproj", "{011BFA92-92BC-404B-B581-9A6C5B7D2C97}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{011BFA92-92BC-404B-B581-9A6C5B7D2C97}.Debug|Win32.ActiveCfg = Debug|Win32
+		{011BFA92-92BC-404B-B581-9A6C5B7D2C97}.Debug|Win32.Build.0 = Debug|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/C/xpcExample/xpcExample.win/xpcExample.vcxproj
+++ b/C/xpcExample/xpcExample.win/xpcExample.vcxproj
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{011BFA92-92BC-404B-B581-9A6C5B7D2C97}</ProjectGuid>
+    <RootNamespace>xpcExample</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <IncludePath>..\..\..\C\src;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\xplaneConnect.c" />
+    <ClCompile Include="..\xpcExample\src\main.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/C/xpcExample/xpcExample.win/xpcExample.vcxproj.filters
+++ b/C/xpcExample/xpcExample.win/xpcExample.vcxproj.filters
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\xpcExample\src\main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\xplaneConnect.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/C/xpcExample/xpcExample/src/main.cpp
+++ b/C/xpcExample/xpcExample/src/main.cpp
@@ -11,121 +11,126 @@
 #include <string.h>
 #include <time.h>
 #include "xplaneConnect.h"
+#ifdef WIN32
+#include <Windows.h>
+#define sleep(n) Sleep(n * 1000)
+#endif
 
 int main() {
-    int i,j;
-    struct xpcSocket sendfd,readfd;
-    float data[4][9] = {0};
-    char DREF[100] = {0};
-    char DREFArray[100][100];
-    char DREFArray2[100][100];
-    short DREFSizes[100];
-    float *recDATA[100];
-    float POSI[9] = {0.0};
-    float CTRL[5] = {0.0};
-    float gear;
-    char IP[16] = "127.0.0.1";// //IP Address of computer running X-Plane
-    short PORT = 49009; //xpcPlugin Receiving port (usually 49009)
-    
-    printf("xplaneconnect Example Script\n- Setting up Simulation\n");
-    
-    for (i = 0; i < 100; i++) {
-        recDATA[i]   = (float *) malloc(40*sizeof(float));
-        memset(DREFArray[i],0,100);
-        memset(DREFArray2[i],0,100);
-    }
-    
-    // Open Sockets
-        readfd = openUDP(49055, IP, PORT); //Open socket for receiving
-        sendfd = openUDP(49077, IP, PORT); //Open socket for sending
-    
-    // Set up Connection
-        setCONN(sendfd, 49055); // Setup so data will be received on port 49055
-    
-    // Set Location/Orientation (sendPOSI)
-        // Set Up Position Array
-            POSI[0] = 37.524; // Lat
-            POSI[1] = -122.06899; // Lon
-            POSI[2] = 2500; // Alt
-            POSI[3] = 0; // Pitch
-            POSI[4] = 0; // Roll
-            POSI[5] = 0; // Heading
-            POSI[6] = 1; // Gear
-    
-        sendPOSI(sendfd, 0, 7, POSI);
-        POSI[0] = 37.52465;
-        POSI[4] = 20;
-        sendPOSI(sendfd, 1, 7, POSI);
-    
-    // Set Rates (sendDATA)
-    
-        for (i=0;i<4;i++) { // Set array to -999
-            for (j=0;j<9;j++) data[i][j] = -999;
-        }
-        // Set up Data Array (first item in row is item number (example: 20=position)
-            data[0][0] = 18; // Alpha
-            data[0][1] = 0;
-            data[0][3] = 0;
-    
-            data[1][0] = 3;//21;  //Velocity
-            data[1][1] = 130;
-            data[1][2] = 130;
-            data[1][3] = 130;
-            data[1][4] = 130;
-    
-            data[2][0] = 16; //PQR
-            data[2][1] = 0;
-            data[2][2] = 0;
-            data[2][3] = 0;
-    
-        sendDATA(sendfd, data, 3); // Throttle/Velocity/Alpha/PQR
-    
-    // Set CTRL
-        CTRL[3] = 0.8; // Throttle
-    
-        sendCTRL(sendfd, 4, CTRL);
-    
-    // pauseSim
-        pauseSim(sendfd, 1); // Sending 1 to pause
-    
-    // Pause for 5 seconds
-        sleep(5);
-    
-    // Unpause
-        pauseSim(sendfd, 0); // Sending 0 to unpause
-        printf("- Resuming Simulation\n");
-    
-    // Simulate for 10 seconds
-        sleep(10);
-    
-    // SendDREF (Landing Gear)
-        printf("- Stowing Landing Gear\n");
-    
-        strcpy(DREF,"cockpit/switches/gear_handle_status"); // Gear handle data reference
-        DREFSizes[0] = sizeof(DREF);
-        gear = 1; // Stow gear
-    
-        sendDREF(sendfd, DREF, DREFSizes[0], &gear, 1); // Set gear to stow
-    
-    // Simulate for 10 seconds
-        sleep(10);
-    
-    // Check Landing gear, Pause
-        printf("- Confirming Gear Status\n");
-        strcpy(DREFArray2[0],"sim/cockpit/switches/gear_handle_status");
-        strcpy(DREFArray2[1],"sim/operation/override/override_planepath");
-        for (i=0;i<2;i++) {
-            DREFSizes[i] = (int) strlen(DREFArray2[i]);
-        }
-        requestDREF(sendfd, readfd, DREFArray2, DREFSizes, 2, recDATA, DREFSizes); // Request 2 values
-    
-        if (*(recDATA[0])==0) {
-            printf("\tGear Stowed\n");
-        } else {
-            printf("\tERROR: Gear Stowage unsuccessful\n");
-        }
-    
-    printf("---End Program---\n");
-    
-    return 0;
+	int i, j;
+	struct xpcSocket sendfd, readfd;
+	float data[4][9] = { 0 };
+	char DREF[100] = { 0 };
+	char DREFArray[100][100];
+	char DREFArray2[100][100];
+	short DREFSizes[100];
+	float *recDATA[100];
+	float POSI[9] = { 0.0 };
+	float CTRL[5] = { 0.0 };
+	float gear;
+	char IP[16] = "127.0.0.1"; //IP Address of computer running X-Plane
+	short PORT = 49009;        //xpcPlugin Receiving port (usually 49009)
+
+	printf("xplaneconnect Example Script\n- Setting up Simulation\n");
+
+	for (i = 0; i < 100; i++) {
+		recDATA[i] = (float *)malloc(40 * sizeof(float));
+		memset(DREFArray[i], 0, 100);
+		memset(DREFArray2[i], 0, 100);
+	}
+
+	// Open Sockets
+	readfd = openUDP(49055, IP, PORT); //Open socket for receiving
+	sendfd = openUDP(49077, IP, PORT); //Open socket for sending
+
+	// Set up Connection
+	setCONN(sendfd, 49055); // Setup so data will be received on port 49055
+
+	// Set Location/Orientation (sendPOSI)
+	// Set Up Position Array
+	POSI[0] = 37.524;     // Lat
+	POSI[1] = -122.06899; // Lon
+	POSI[2] = 2500;       // Alt
+	POSI[3] = 0;          // Pitch
+	POSI[4] = 0;          // Roll
+	POSI[5] = 0;          // Heading
+	POSI[6] = 1;          // Gear
+
+	sendPOSI(sendfd, 0, 7, POSI);
+	POSI[0] = 37.52465;   // Move a second aircraft a bit North of us
+	POSI[4] = 20;         // Give that aircraft a bit or right roll
+	sendPOSI(sendfd, 1, 7, POSI);
+
+	// Set Rates (sendDATA)
+
+	for (i = 0; i < 4; i++) { // Set array to -999
+		for (j = 0; j < 9; j++) data[i][j] = -999;
+	}
+	// Set up Data Array (first item in row is item number (example: 20=position)
+	data[0][0] = 18; // Alpha
+	data[0][1] = 0;
+	data[0][3] = 0;
+
+	data[1][0] = 3;//21;  //Velocity
+	data[1][1] = 130;
+	data[1][2] = 130;
+	data[1][3] = 130;
+	data[1][4] = 130;
+
+	data[2][0] = 16; //PQR
+	data[2][1] = 0;
+	data[2][2] = 0;
+	data[2][3] = 0;
+
+	sendDATA(sendfd, data, 3); // Velocity/Alpha/PQR
+
+	// Set CTRL
+	CTRL[3] = 0.8; // Throttle
+
+	sendCTRL(sendfd, 4, CTRL);
+
+	// pauseSim
+	pauseSim(sendfd, 1); // Sending 1 to pause
+
+	// Pause for 5 seconds
+	sleep(5);
+
+	// Unpause
+	pauseSim(sendfd, 0); // Sending 0 to unpause
+	printf("- Resuming Simulation\n");
+
+	// Simulate for 10 seconds
+	sleep(10);
+
+	// SendDREF (Landing Gear)
+	printf("- Stowing Landing Gear\n");
+
+	strcpy(DREF, "cockpit/switches/gear_handle_status"); // Gear handle data reference
+	DREFSizes[0] = strlen(DREF);
+	gear = 1; // Stow gear
+
+	sendDREF(sendfd, DREF, DREFSizes[0], &gear, 1); // Set gear to stow
+
+	// Simulate for 10 seconds
+	sleep(10);
+
+	// Check Landing gear, Pause
+	printf("- Confirming Gear Status\n");
+	strcpy(DREFArray2[0], "sim/cockpit/switches/gear_handle_status");
+	strcpy(DREFArray2[1], "sim/operation/override/override_planepath");
+	for (i = 0; i < 2; i++) {
+		DREFSizes[i] = (int)strlen(DREFArray2[i]);
+	}
+	requestDREF(sendfd, readfd, DREFArray2, DREFSizes, 2, recDATA, DREFSizes); // Request 2 values
+
+	if (*(recDATA[0]) == 0) {
+		printf("\tGear Stowed\n");
+	}
+	else {
+		printf("\tERROR: Gear Stowage unsuccessful\n");
+	}
+
+	printf("---End Program---\n");
+
+	return 0;
 }

--- a/MATLAB/+XPlaneConnect/sendCTRL.m
+++ b/MATLAB/+XPlaneConnect/sendCTRL.m
@@ -47,7 +47,7 @@ import XPlaneConnect.*
     dataStream = header; %TODO-ADD ACFT
     
     % Deal with position update
-    control = [0, 0, 0, 0.8, 0, 1];
+    control = [-998.5, -998.5, -998.5, -998.5, -998.5, -998.5];
     
     for i=1:min(length(ctrl),length(control))
         control(i) = ctrl(i);

--- a/MATLAB/Example/Example.m
+++ b/MATLAB/Example/Example.m
@@ -12,31 +12,28 @@ disp('xplaneconnect Example Script\n- Setting up Simulation');
 Socket = openUDP(49005);
 %% Set position of the player aircraft
 disp('Setting position');
+ pauseSim(1);
 %       Lat     Lon         Alt   Pitch Roll Heading Gear
 POSI = [37.524, -122.06899, 2500, 0,    0,   0,      1];
-sendPOSI(POSI);
-pause(5);
-posi(1) = 37.52465;   % Move aircraft North a bit
-posi(4) = 20;         % Set aircraft pitch up 20 degrees
-sendPOSI(POSI);
+sendPOSI(POSI); % Set own aircraft position
+
+%       Lat     Lon           Alt   Pitch Roll Heading Gear
+POSI = [37.52465, -122.06899, 2500, 0,    20,  0,      1];
+sendPOSI(POSI, 1); % Place another aircraft just north of us
 %% Set rates
 disp('Setting rates');
-data = struct('h',18,'d',[0,-999,0,-999,-999,-999,-999,-999]);
-sendDATA(data);
-data = struct('h',3,'d',[3,130,130,130,130,-999,-999,-999]);
-sendDATA(data);
-data = struct('h',16,'d',[16,0,0,0,-999,-999,-999,-999]);
-sendDATA(data);
 %                  Alpha Velocity PQR
-% data = struct('h',[18,   3,       16],...
-%               'd',[[0,-999,0,-999,-999,-999,-999,-999],... % Alpha data
-%                    [3,130,130,130,130,-999,-999,-999],...  % Velocity data
-%                    [16,0,0,0,-999,-999,-999,-999]]);       % PQR data
-% sendDATA(data);
+data = struct('h',[18,   3,       16],...
+              'd',[0,-999,0,-999,-999,-999,-999,-999;... % Alpha data
+                   3,130,130,130,130,-999,-999,-999;...  % Velocity data
+                   16,0,0,0,-999,-999,-999,-999]);       % PQR data
+sendDATA(data);
  %% Set CTRL
  %                      Throttle
- CTRL = [-999,-999,-999,0.8,-999];
+ CTRL = [0,0,0.8];
  sendCTRL(CTRL);
+ pause(5);
+ pauseSim(0);
  pause(5) % Run sim for 5 seconds
  %% Pause sim
  disp('Pausing simulation');

--- a/MATLAB/Example/Example.m
+++ b/MATLAB/Example/Example.m
@@ -8,7 +8,8 @@ import XPlaneConnect.*
 %% Setup
 % Create variables and open connection to X-Plane
 
-disp('xplaneconnect Example Script\n- Setting up Simulation');
+disp('xplaneconnect Example Script-');
+disp('Setting up Simulation');
 Socket = openUDP(49005);
 %% Set position of the player aircraft
 disp('Setting position');
@@ -25,12 +26,12 @@ disp('Setting rates');
 %                  Alpha Velocity PQR
 data = struct('h',[18,   3,       16],...
               'd',[0,-999,0,-999,-999,-999,-999,-999;... % Alpha data
-                   3,130,130,130,130,-999,-999,-999;...  % Velocity data
-                   16,0,0,0,-999,-999,-999,-999]);       % PQR data
+                   130,130,130,130,-999,-999,-999,-999;...  % Velocity data
+                   0,0,0,-999,-999,-999,-999,-999]);       % PQR data
 sendDATA(data);
  %% Set CTRL
  %                      Throttle
- CTRL = [0,0,0.8];
+ CTRL = [0,0,0,0.8];
  sendCTRL(CTRL);
  pause(5);
  pauseSim(0);

--- a/TestScripts/C Tests/main.c
+++ b/TestScripts/C Tests/main.c
@@ -461,7 +461,7 @@ short connTest() // setConn test
     
     // Set up for next test
     sendPort = openUDP( 49067, "127.0.0.1", 49009 );
-    setCONN(sendPort, 49009);
+    setCONN(sendPort, 49008);
     closeUDP(sendPort);
     return 0;
 }

--- a/TestScripts/CPP Tests/main.cpp
+++ b/TestScripts/CPP Tests/main.cpp
@@ -453,7 +453,7 @@ void connTest() // setConn test
     
     // Set up for next test
         sendPort = openUDP( 49067, "127.0.0.1", 49009 );
-        setCONN(sendPort, 49009);
+        setCONN(sendPort, 49008);
         closeUDP(sendPort);
 }
 


### PR DESCRIPTION
 - Added Visual Studio solution for C client example.
 - Fixed inconsistent indentation in C client example.
 - Changed default behavior in MATLAB client's sendCTRL function to leave unchanged instead of setting default values.
 - Fixed sendPOSI and sendDATA sections of the MATLAB example.
 - Fixed port number in the C and C++ setCONN tests.