### PR TITLE
Fixed setCONN and tweaked pauseSim in MATLAB client

### DIFF
--- a/MATLAB/+XPlaneConnect/pauseSim.m
+++ b/MATLAB/+XPlaneConnect/pauseSim.m
@@ -35,11 +35,10 @@ import XPlaneConnect.*
     % Check format of input-TODO
 
 %% BODY
-    message = zeros(1,7);
+    message = zeros(1,6);
     
     message(1:4) = 'SIMU'-0;
     message(6) = uint8(p.Results.pause);
-    message(7) = 0;
 
     status = sendUDP(message, p.Results.IP, p.Results.port);
 end

--- a/MATLAB/+XPlaneConnect/readUDP.m
+++ b/MATLAB/+XPlaneConnect/readUDP.m
@@ -1,4 +1,4 @@
-function [ data ] = readUDP( input )
+function [ data ] = readUDP( varargin )
 %readUDP Read Array from UDP Socket
 % 
 % Inputs
@@ -36,9 +36,20 @@ function [ data ] = readUDP( input )
     bits = 2000;
     
     %% Interpret Input
-    socket = input;
-    if isnumeric(input) 
-        socket=openUDP(input);
+    global udpReadPort;
+    if isempty(varargin)
+        if isempty(udpReadPort)
+            udpReadPort = 49008;
+        end
+        socket = openUDP(udpReadPort);
+        ownSocket = 1;
+    else
+        socket = varargin{1};
+        ownSocket = 0;
+        if isnumeric(varargin{1}) 
+            socket=openUDP(varargin{1});
+            ownSocket = 1;
+        end
     end
     
     %% Try reading packet
@@ -65,7 +76,7 @@ function [ data ] = readUDP( input )
     end
     
     %% Close Port (if opened in code)
-    if isnumeric(input)
+    if ownSocket
         socket.close()
     end
 end

--- a/MATLAB/+XPlaneConnect/requestDREF.m
+++ b/MATLAB/+XPlaneConnect/requestDREF.m
@@ -24,7 +24,6 @@ import XPlaneConnect.*
 
 message = zeros(1,6);
 len = 7;
-socket = openUDP(49008);
 status = -1; %#ok<NASGU> % no data
 
 %% Handle Input
@@ -51,7 +50,7 @@ parse(p,DREFArray,varargin{:});
         
     % Look for response 
         for i=1:40
-            data = readUDP(socket);
+            data = readUDP();
             if length(data) > 1 % Received Data
                 status = 0;
                 counter = 7;
@@ -66,6 +65,5 @@ parse(p,DREFArray,varargin{:});
             else
                 result = cell(0,1);
             end
-        end
-closeUDP(socket);      
+        end 
 end

--- a/MATLAB/+XPlaneConnect/setConn.m
+++ b/MATLAB/+XPlaneConnect/setConn.m
@@ -25,7 +25,7 @@ function status = setConn( recvPort, IP, port )
     import XPlaneConnect.*
 
     status = 0;
-    message = zeros(1,9);
+    message = zeros(1,7);
     
 %% Handle Input
     % Optional parameters
@@ -39,9 +39,12 @@ function status = setConn( recvPort, IP, port )
         message(1:4) = 'CONN'-0;
     
     % RecvPort
-        message(6:9) = typecast(uint32(recvPort),'uint8');
+        message(6:7) = typecast(uint16(recvPort),'uint8');
         
     % Send
-        sendUDP(IP,port,message);
+        sendUDP(message,IP,port);
+        
+        global udpReadPort;
+        udpReadPort = recvPort;
 
 end

--- a/TestScripts/MATLAB Tests/setConnTest.m
+++ b/TestScripts/MATLAB Tests/setConnTest.m
@@ -1,6 +1,5 @@
 function setConnTest(  )
 
-disp('Not Functional Yet!')
 %setConnTest Summary of this function goes here
 %   Detailed explanation goes here
 addpath('../../MATLAB')


### PR DESCRIPTION
 - setCONN is functional, although it should probably be revisited at some point to see if the same functionality can be achieved without using globals
 - pauseSim now sends the same number of bytes as its C sibling.