### PR TITLE
fix osx ambiguity

### DIFF
--- a/xpcPlugin/XPCPlugin.cpp
+++ b/xpcPlugin/XPCPlugin.cpp
@@ -67,6 +67,7 @@
 // System Includes
 #include <cstdlib>
 #include <cstring>
+#include <cmath>
 #ifdef __APPLE__
 #include <mach/mach_time.h>
 #endif
@@ -95,8 +96,7 @@ PLUGIN_API int XPluginStart(char* outName, char* outSig, char* outDesc)
 	strcpy(outDesc, "X Plane Communications Toolbox\nCopyright (c) 2013-2018 United States Government as represented by the Administrator of the National Aeronautics and Space Administration. All Rights Reserved.");
 
 #if (__APPLE__)
-	int (*_abs)( int ) = & std::abs; // Needed to resolve ambiguity for OS X compilation
-	if ( _abs(timeConvert) <= 1e-9 ) // is about 0
+	if ( abs(timeConvert) <= 1e-9 ) // is about 0
 	{
 		mach_timebase_info_data_t timeBase;
 		(void)mach_timebase_info(&timeBase);


### PR DESCRIPTION
This one uses a header instead of pointer galore for this ambiguity issue.