### PR TITLE
Runway camera location control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 # OS generated files #
 ######################
 .DS_Store?
+.DS_Store
 ehthumbs.db
 Icon?
 Thumbs.db
@@ -69,6 +70,7 @@ build/
 xcuserdata
 *.moved-aside
 *.xccheckout
+xcshareddata
 
 # IntelliJ Files #
 ##################

--- a/xpcPlugin/MessageHandlers.cpp
+++ b/xpcPlugin/MessageHandlers.cpp
@@ -695,17 +695,28 @@ namespace XPC
 		// Update Log
 		Log::FormatLine(LOG_TRACE, "VIEW", "Message Received(Conn %i)", connection.id);
 
+        int enable_camera_location = 0;
+        
 		const std::size_t size = msg.GetSize();
-		if (size != 37)
+		if (size == 9)
+        {
+            // default view switcher as before
+        }
+        else if (size == 37)
 		{
-			Log::FormatLine(LOG_ERROR, "VIEW", "Error: Unexpected length. Message was %d bytes, expected 37.", size);
-			return;
+            // Allow camera location control
+            enable_camera_location = 1;
 		}
+        else
+        {
+            Log::FormatLine(LOG_ERROR, "VIEW", "Error: Unexpected length. Message was %d bytes, expected 9 or 37.", size);
+            return;
+        }
         const unsigned char* buffer = msg.GetBuffer();
         int type = *((int*)(buffer + 5));
         XPLMCommandKeyStroke(type);
         
-        if(type == 79) // fixed camera view
+        if(type == 79 && enable_camera_location == 1) // runway camera view
         {
             static struct camera_properties campos;
         

--- a/xpcPlugin/MessageHandlers.cpp
+++ b/xpcPlugin/MessageHandlers.cpp
@@ -20,9 +20,12 @@
 #include "Log.h"
 
 #include "XPLMUtilities.h"
+#include "XPLMGraphics.h"
+
 
 #include <cmath>
 #include <cstring>
+
 
 namespace XPC
 {
@@ -597,7 +600,7 @@ namespace XPC
 		// Update log
 		Log::FormatLine(LOG_TRACE, "SIMU", "Message Received (Conn %i)", connection.id);
 
-		char v = msg.GetBuffer()[5];
+		unsigned char v = msg.GetBuffer()[5];
 		if (v < 0 || (v > 2 && v < 100) || (v > 119 && v < 200) || v > 219)
 		{
 			Log::FormatLine(LOG_ERROR, "SIMU", "ERROR: Invalid argument: %i", v);
@@ -686,7 +689,7 @@ namespace XPC
 			Log::WriteLine(LOG_INFO, "TEXT", "[TEXT] Text set");
 		}
 	}
-
+    
 	void MessageHandlers::HandleView(const Message& msg)
 	{
 		// Update Log
@@ -698,10 +701,73 @@ namespace XPC
 			Log::FormatLine(LOG_ERROR, "VIEW", "Error: Unexpected length. Message was %d bytes, expected 9.", size);
 			return;
 		}
-		const unsigned char* buffer = msg.GetBuffer();
-		int type = *((int*)(buffer + 5));
-		XPLMCommandKeyStroke(type);
+        const unsigned char* buffer = msg.GetBuffer();
+        int type = *((int*)(buffer + 5));
+        XPLMCommandKeyStroke(type);
+        
+        if(type == 79) // fixed camera view
+        {
+            static struct camera_properties campos;
+        
+            campos.loc[0] = 48.0741;
+            campos.loc[1] = 11.2731;
+            campos.loc[2] = 1.8;
+            campos.zoom = 1.0;
+        
+            XPLMControlCamera(xplm_ControlCameraUntilViewChanges, CamFunc, &campos);
+        }
 	}
+    
+    int MessageHandlers::CamFunc( XPLMCameraPosition_t * outCameraPosition, int inIsLosingControl, void *inRefcon)
+    {
+        if (outCameraPosition && !inIsLosingControl)
+        {
+            struct camera_properties* campos = (struct camera_properties*)inRefcon;
+            
+            // camera position
+            double clat = campos->loc[0];
+            double clon = campos->loc[1];
+            double calt = campos->loc[2];
+            
+            double cX, cY, cZ;
+            XPLMWorldToLocal(clat, clon, calt, &cX, &cY, &cZ);
+            
+            outCameraPosition->x = cX;
+            outCameraPosition->y = cY;
+            outCameraPosition->z = cZ;
+            
+//            Log::FormatLine(LOG_TRACE, "CAM", "Cam pos %f %f %f", clat, clon, calt);
+            
+            // aircraft position
+            double x = XPC::DataManager::GetDouble(XPC::DREF_LocalX, 0);
+            double y = XPC::DataManager::GetDouble(XPC::DREF_LocalY, 0);
+            double z = XPC::DataManager::GetDouble(XPC::DREF_LocalZ, 0);
+            
+            // relative position vector cam to plane
+            double dx = x - cX;
+            double dy = y - cY;
+            double dz = z - cZ;
+            
+//            Log::FormatLine(LOG_TRACE, "CAM", "Cam vect %f %f %f", dx, dy, dz);
+            
+            double pi = 3.141592653589793;
+            
+            // horizontal distance
+            double dist = sqrt(dx*dx + dz*dz);
+            
+            outCameraPosition->pitch = atan2(dy, dist) * 180.0/pi;
+            
+            double angle = atan2(dz, dx) * 180.0/pi; // rel to pos right (pos X)
+            outCameraPosition->heading = 90 + angle; // rel to north
+            
+//            Log::FormatLine(LOG_TRACE, "CAM", "Cam p %f hdg %f ", outCameraPosition->pitch, outCameraPosition->heading);
+            
+            outCameraPosition->roll = 0;
+            outCameraPosition->zoom = campos->zoom;
+        }
+        
+        return 1;
+    }
 
 	void MessageHandlers::HandleWypt(const Message& msg)
 	{

--- a/xpcPlugin/MessageHandlers.cpp
+++ b/xpcPlugin/MessageHandlers.cpp
@@ -713,6 +713,8 @@ namespace XPC
             campos.loc[1] = *(double*)(buffer+17);
             campos.loc[2] = *(double*)(buffer+25);
             campos.zoom   = *(float*)(buffer+33);
+            
+            Log::FormatLine(LOG_TRACE, "VIEW", "Cam pos %f %f %f zoom %f", campos.loc[0], campos.loc[1], campos.loc[2],campos.zoom);
         
             XPLMControlCamera(xplm_ControlCameraUntilViewChanges, CamFunc, &campos);
         }
@@ -758,6 +760,7 @@ namespace XPC
             outCameraPosition->pitch = atan2(dy, dist) * 180.0/pi;
             
             double angle = atan2(dz, dx) * 180.0/pi; // rel to pos right (pos X)
+            
             outCameraPosition->heading = 90 + angle; // rel to north
             
 //            Log::FormatLine(LOG_TRACE, "CAM", "Cam p %f hdg %f ", outCameraPosition->pitch, outCameraPosition->heading);

--- a/xpcPlugin/MessageHandlers.cpp
+++ b/xpcPlugin/MessageHandlers.cpp
@@ -718,7 +718,7 @@ namespace XPC
 		
 		if(type == 79 && enable_camera_location == 1) // runway camera view
 		{
-			static struct camera_properties campos;
+			static struct CameraProperties campos;
 		
 			campos.loc[0] = *(double*)(buffer+9);
 			campos.loc[1] = *(double*)(buffer+17);
@@ -735,7 +735,7 @@ namespace XPC
 	{
 		if (outCameraPosition && !inIsLosingControl)
 		{
-			struct camera_properties* campos = (struct camera_properties*)inRefcon;
+			struct CameraProperties* campos = (struct CameraProperties*)inRefcon;
 			
 			// camera position
 			double clat = campos->loc[0];

--- a/xpcPlugin/MessageHandlers.cpp
+++ b/xpcPlugin/MessageHandlers.cpp
@@ -696,9 +696,9 @@ namespace XPC
 		Log::FormatLine(LOG_TRACE, "VIEW", "Message Received(Conn %i)", connection.id);
 
 		const std::size_t size = msg.GetSize();
-		if (size != 9)
+		if (size != 37)
 		{
-			Log::FormatLine(LOG_ERROR, "VIEW", "Error: Unexpected length. Message was %d bytes, expected 9.", size);
+			Log::FormatLine(LOG_ERROR, "VIEW", "Error: Unexpected length. Message was %d bytes, expected 37.", size);
 			return;
 		}
         const unsigned char* buffer = msg.GetBuffer();
@@ -709,10 +709,10 @@ namespace XPC
         {
             static struct camera_properties campos;
         
-            campos.loc[0] = 48.0741;
-            campos.loc[1] = 11.2731;
-            campos.loc[2] = 1.8;
-            campos.zoom = 1.0;
+            campos.loc[0] = *(double*)(buffer+9);
+            campos.loc[1] = *(double*)(buffer+17);
+            campos.loc[2] = *(double*)(buffer+25);
+            campos.zoom   = *(float*)(buffer+33);
         
             XPLMControlCamera(xplm_ControlCameraUntilViewChanges, CamFunc, &campos);
         }

--- a/xpcPlugin/MessageHandlers.cpp
+++ b/xpcPlugin/MessageHandlers.cpp
@@ -723,6 +723,9 @@ namespace XPC
 			campos.loc[0] = *(double*)(buffer+9);
 			campos.loc[1] = *(double*)(buffer+17);
 			campos.loc[2] = *(double*)(buffer+25);
+            campos.direction[0] = -998;
+            campos.direction[1] = -998;
+            campos.direction[2] = -998;
 			campos.zoom	  = *(float*)(buffer+33);
 			
 			Log::FormatLine(LOG_TRACE, "VIEW", "Cam pos %f %f %f zoom %f", campos.loc[0], campos.loc[1], campos.loc[2],campos.zoom);
@@ -751,32 +754,42 @@ namespace XPC
 			
 //			  Log::FormatLine(LOG_TRACE, "CAM", "Cam pos %f %f %f", clat, clon, calt);
 			
-			// aircraft position
-			double x = XPC::DataManager::GetDouble(XPC::DREF_LocalX, 0);
-			double y = XPC::DataManager::GetDouble(XPC::DREF_LocalY, 0);
-			double z = XPC::DataManager::GetDouble(XPC::DREF_LocalZ, 0);
+            if(campos->direction[0] == -998) // calculate camera direction
+            {
+                // aircraft position
+                double x = XPC::DataManager::GetDouble(XPC::DREF_LocalX, 0);
+                double y = XPC::DataManager::GetDouble(XPC::DREF_LocalY, 0);
+                double z = XPC::DataManager::GetDouble(XPC::DREF_LocalZ, 0);
 			
-			// relative position vector cam to plane
-			double dx = x - cX;
-			double dy = y - cY;
-			double dz = z - cZ;
+                // relative position vector cam to plane
+                double dx = x - cX;
+                double dy = y - cY;
+                double dz = z - cZ;
 			
-//			  Log::FormatLine(LOG_TRACE, "CAM", "Cam vect %f %f %f", dx, dy, dz);
+//			    Log::FormatLine(LOG_TRACE, "CAM", "Cam vect %f %f %f", dx, dy, dz);
 			
-			double pi = 3.141592653589793;
+                double pi = 3.141592653589793;
 			
-			// horizontal distance
-			double dist = sqrt(dx*dx + dz*dz);
+                // horizontal distance
+                double dist = sqrt(dx*dx + dz*dz);
 			
-			outCameraPosition->pitch = atan2(dy, dist) * 180.0/pi;
+                outCameraPosition->pitch = atan2(dy, dist) * 180.0/pi;
 			
-			double angle = atan2(dz, dx) * 180.0/pi; // rel to pos right (pos X)
+                double angle = atan2(dz, dx) * 180.0/pi; // rel to pos right (pos X)
 			
-			outCameraPosition->heading = 90 + angle; // rel to north
+                outCameraPosition->heading = 90 + angle; // rel to north
 			
-//			  Log::FormatLine(LOG_TRACE, "CAM", "Cam p %f hdg %f ", outCameraPosition->pitch, outCameraPosition->heading);
+//			    Log::FormatLine(LOG_TRACE, "CAM", "Cam p %f hdg %f ", outCameraPosition->pitch, outCameraPosition->heading);
 			
-			outCameraPosition->roll = 0;
+                outCameraPosition->roll = 0;
+            }
+            else
+            {
+                outCameraPosition->roll     = campos->direction[0];
+                outCameraPosition->pitch    = campos->direction[1];
+                outCameraPosition->heading  = campos->direction[2];
+            }
+            
 			outCameraPosition->zoom = campos->zoom;
 		}
 		

--- a/xpcPlugin/MessageHandlers.h
+++ b/xpcPlugin/MessageHandlers.h
@@ -7,6 +7,9 @@
 #include <string>
 #include <map>
 
+#include "XPLMCamera.h"
+
+
 namespace XPC
 {
 	/// A function that handles a message.
@@ -54,6 +57,14 @@ namespace XPC
 
 		static void HandleXPlaneData(const Message& msg);
 		static void HandleUnknown(const Message& msg);
+        
+        static int CamFunc( XPLMCameraPosition_t * outCameraPosition, int inIsLosingControl, void *inRefcon);
+        
+        struct camera_properties{
+            double loc[3];
+            float direction[3];
+            float zoom;
+        };
 
 		typedef struct
 		{

--- a/xpcPlugin/MessageHandlers.h
+++ b/xpcPlugin/MessageHandlers.h
@@ -60,7 +60,7 @@ namespace XPC
 		
 		static int CamFunc( XPLMCameraPosition_t * outCameraPosition, int inIsLosingControl, void *inRefcon);
 		
-		struct camera_properties{
+		struct CameraProperties{
 			double loc[3];
 			float direction[3];
 			float zoom;

--- a/xpcPlugin/MessageHandlers.h
+++ b/xpcPlugin/MessageHandlers.h
@@ -29,10 +29,10 @@ namespace XPC
 		/// socket.
 		///
 		/// \details After a message is read, HandleMessage analyzes the sender's network address
-		///          to determine whether the sender is a new client. It then either loads
-		///          connection details for an existing client, or creates a new connection record
-		///          for new clients. Finally, the message handler checks the message type and
-		///          dispatches the message to the appropriate handler.
+		///			 to determine whether the sender is a new client. It then either loads
+		///			 connection details for an existing client, or creates a new connection record
+		///			 for new clients. Finally, the message handler checks the message type and
+		///			 dispatches the message to the appropriate handler.
 		/// \param msg The message to be processed.
 		static void HandleMessage(Message& msg);
 
@@ -57,14 +57,14 @@ namespace XPC
 
 		static void HandleXPlaneData(const Message& msg);
 		static void HandleUnknown(const Message& msg);
-        
-        static int CamFunc( XPLMCameraPosition_t * outCameraPosition, int inIsLosingControl, void *inRefcon);
-        
-        struct camera_properties{
-            double loc[3];
-            float direction[3];
-            float zoom;
-        };
+		
+		static int CamFunc( XPLMCameraPosition_t * outCameraPosition, int inIsLosingControl, void *inRefcon);
+		
+		struct camera_properties{
+			double loc[3];
+			float direction[3];
+			float zoom;
+		};
 
 		typedef struct
 		{


### PR DESCRIPTION
This PR enables to control the location and zoom of the runway camera to simulate a remotely controlled aircraft piloting experience.

If an extended view message is received, the view is switched to runway view and the camera is placed at the coordinates specified in the message, pointing at the aircraft in pitch and yaw.

Default behaviour with the standard view message ensures compatibility with existing software.