### PR TITLE
Added UDP multicast for plugin discovery

### DIFF
--- a/xpcPlugin/CMakeLists.txt
+++ b/xpcPlugin/CMakeLists.txt
@@ -10,7 +10,7 @@ add_definitions(-DXPLM200 -DLIN=1)
 
 SET(CMAKE_C_COMPILER gcc)
 SET(CMAKE_CXX_COMPILER g++)
-set (CMAKE_CXX_STANDARD 11)
+SET(CMAKE_CXX_STANDARD 11)
 
 add_library(xpc64 SHARED XPCPlugin.cpp
 	DataManager.cpp

--- a/xpcPlugin/CMakeLists.txt
+++ b/xpcPlugin/CMakeLists.txt
@@ -10,6 +10,7 @@ add_definitions(-DXPLM200 -DLIN=1)
 
 SET(CMAKE_C_COMPILER gcc)
 SET(CMAKE_CXX_COMPILER g++)
+set (CMAKE_CXX_STANDARD 11)
 
 add_library(xpc64 SHARED XPCPlugin.cpp
 	DataManager.cpp

--- a/xpcPlugin/CMakeLists.txt
+++ b/xpcPlugin/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(xpc64 SHARED XPCPlugin.cpp
 	Log.cpp
 	Message.cpp
 	MessageHandlers.cpp
+	Timer.cpp
 	UDPSocket.cpp)
 set_target_properties(xpc64 PROPERTIES PREFIX "" SUFFIX ".xpl")
 set_target_properties(xpc64 PROPERTIES COMPILE_FLAGS "-m64 -fno-stack-protector" LINK_FLAGS "-shared -rdynamic -nodefaultlibs -undefined_warning -m64 -fno-stack-protector")
@@ -28,6 +29,7 @@ add_library(xpc32 SHARED XPCPlugin.cpp
 	Log.cpp
 	Message.cpp
 	MessageHandlers.cpp
+	Timer.cpp
 	UDPSocket.cpp)
 set_target_properties(xpc32 PROPERTIES PREFIX "" SUFFIX ".xpl")
 set_target_properties(xpc32 PROPERTIES COMPILE_FLAGS "-m32 -fno-stack-protector" LINK_FLAGS "-shared -rdynamic -nodefaultlibs -undefined_warning -m32 -fno-stack-protector")

--- a/xpcPlugin/MessageHandlers.cpp
+++ b/xpcPlugin/MessageHandlers.cpp
@@ -136,12 +136,16 @@ namespace XPC
 		}
 	}
     
-    void MessageHandlers::SendBeacon(const std::string& pluginVersion, int xplaneVersion) {
+    void MessageHandlers::SendBeacon(const std::string& pluginVersion, unsigned short  pluginReceivePort, int xplaneVersion) {
         
         unsigned char response[128] = "BECN";
         
         std::size_t cur = 5;
-        
+
+        // 2 bytes plugin port
+        *((uint16_t *)(response + cur)) = pluginReceivePort;
+        cur += sizeof(uint16_t);
+
         // 4 bytes xplane version
         *((uint32_t*)(response + cur)) = xplaneVersion;
         cur += sizeof(uint32_t);

--- a/xpcPlugin/MessageHandlers.cpp
+++ b/xpcPlugin/MessageHandlers.cpp
@@ -130,6 +130,15 @@ namespace XPC
 			MessageHandlers::HandleUnknown(msg);
 		}
 	}
+    
+    void MessageHandlers::SendBeacon() {
+        // todo add host ip, plugin version ...
+        unsigned char response[4] = "BCN";
+        
+        // todo define multicast group
+        sockaddr* sa = sock->GetAddr("239.255.1.1", 49710);
+        sock->SendTo(response, 4, sa);
+    }
 
 	void MessageHandlers::HandleConn(const Message& msg)
 	{

--- a/xpcPlugin/MessageHandlers.cpp
+++ b/xpcPlugin/MessageHandlers.cpp
@@ -136,7 +136,7 @@ namespace XPC
 		}
 	}
     
-    void MessageHandlers::SendBeacon(std::string pluginVersion, int xplaneVersion) {
+    void MessageHandlers::SendBeacon(const std::string& pluginVersion, int xplaneVersion) {
         
         unsigned char response[128] = "BECN";
         

--- a/xpcPlugin/MessageHandlers.cpp
+++ b/xpcPlugin/MessageHandlers.cpp
@@ -136,27 +136,20 @@ namespace XPC
 		}
 	}
     
-    void MessageHandlers::SendBeacon() {
+    void MessageHandlers::SendBeacon(std::string pluginVersion, int xplaneVersion) {
         
         unsigned char response[128] = "BECN";
         
         std::size_t cur = 5;
         
         // 4 bytes xplane version
-        int xpVer;
-        int xplmVer;
-        XPLMHostApplicationID hostID;
-        XPLMGetVersions(&xpVer, &xplmVer, &hostID);
-        
-        *((uint32_t*)(response + cur)) = xpVer;
+        *((uint32_t*)(response + cur)) = xplaneVersion;
         cur += sizeof(uint32_t);
         
         // plugin version
-        const char * pluginVersion = "1.3-rc.1";
-        int len = strlen(pluginVersion) + 1;
-        memcpy(response + cur, pluginVersion, len);
-        
-        cur += strlen(pluginVersion) + len;
+        int len = pluginVersion.length();
+        memcpy(response + cur, pluginVersion.c_str(), len);
+        cur += strlen(pluginVersion.c_str()) + len;
         
         sock->SendTo(response, cur, &multicast_address);
     }

--- a/xpcPlugin/MessageHandlers.h
+++ b/xpcPlugin/MessageHandlers.h
@@ -39,7 +39,7 @@ namespace XPC
 		/// Sets the socket that message handlers use to send responses.
 		static void SetSocket(UDPSocket* socket);
         
-        static void SendBeacon();
+        static void SendBeacon(std::string pluginVersion, int xplaneVersion);
 
 	private:
 		// One handler per message type. Message types are descripbed on the

--- a/xpcPlugin/MessageHandlers.h
+++ b/xpcPlugin/MessageHandlers.h
@@ -38,6 +38,8 @@ namespace XPC
 
 		/// Sets the socket that message handlers use to send responses.
 		static void SetSocket(UDPSocket* socket);
+        
+        static void SendBeacon();
 
 	private:
 		// One handler per message type. Message types are descripbed on the

--- a/xpcPlugin/MessageHandlers.h
+++ b/xpcPlugin/MessageHandlers.h
@@ -39,7 +39,7 @@ namespace XPC
 		/// Sets the socket that message handlers use to send responses.
 		static void SetSocket(UDPSocket* socket);
         
-        static void SendBeacon(const std::string& pluginVersion, int xplaneVersion);
+        static void SendBeacon(const std::string& pluginVersion, unsigned short pluginReceivePort, int xplaneVersion);
 
 	private:
 		// One handler per message type. Message types are descripbed on the

--- a/xpcPlugin/MessageHandlers.h
+++ b/xpcPlugin/MessageHandlers.h
@@ -39,7 +39,7 @@ namespace XPC
 		/// Sets the socket that message handlers use to send responses.
 		static void SetSocket(UDPSocket* socket);
         
-        static void SendBeacon(std::string pluginVersion, int xplaneVersion);
+        static void SendBeacon(const std::string& pluginVersion, int xplaneVersion);
 
 	private:
 		// One handler per message type. Message types are descripbed on the

--- a/xpcPlugin/Timer.cpp
+++ b/xpcPlugin/Timer.cpp
@@ -1,0 +1,26 @@
+//
+//  Timer.cpp
+//  Thread
+//
+//  Created by Jan Chaloupecky on 16.12.18.
+//  Copyright © 2018 Jan Chaloupecky. All rights reserved.
+//
+
+#include "Timer.h"
+
+void Timer::start(const chrono::milliseconds interval, const Callback &callback) {
+    {
+        running = true;
+        th = thread([=]()
+                    {
+                        while (running == true) {
+                            this_thread::sleep_for(interval);
+                            callback();
+                        }
+                    });
+    }
+}
+
+void Timer::stop() {
+    running = false;
+}

--- a/xpcPlugin/Timer.cpp
+++ b/xpcPlugin/Timer.cpp
@@ -7,10 +7,10 @@ using namespace std;
 namespace XPC {
     void Timer::start(const chrono::milliseconds interval, const Callback &callback) {
         {
-            running = true;
+            running.test_and_set();
             th = thread([=]()
                         {
-                            while (running == true) {
+                            while (running.test_and_set()) {
                                 this_thread::sleep_for(interval);
                                 callback();
                             }
@@ -19,7 +19,7 @@ namespace XPC {
     }
     
     void Timer::stop() {
-        running = false;
+        running.clear();
         if(th.joinable()) {
             th.join();
         }

--- a/xpcPlugin/Timer.cpp
+++ b/xpcPlugin/Timer.cpp
@@ -1,10 +1,5 @@
-//
-//  Timer.cpp
-//  Thread
-//
-//  Created by Jan Chaloupecky on 16.12.18.
-//  Copyright © 2018 Jan Chaloupecky. All rights reserved.
-//
+// Copyright (c) 2013-2018 United States Government as represented by the Administrator of the
+// National Aeronautics and Space Administration. All Rights Reserved.
 
 #include "Timer.h"
 

--- a/xpcPlugin/Timer.cpp
+++ b/xpcPlugin/Timer.cpp
@@ -2,6 +2,7 @@
 // National Aeronautics and Space Administration. All Rights Reserved.
 
 #include "Timer.h"
+using namespace std;
 
 namespace XPC {
     void Timer::start(const chrono::milliseconds interval, const Callback &callback) {
@@ -19,6 +20,8 @@ namespace XPC {
     
     void Timer::stop() {
         running = false;
-        th.join();
+        if(th.joinable()) {
+            th.join();
+        }
     }
 }

--- a/xpcPlugin/Timer.cpp
+++ b/xpcPlugin/Timer.cpp
@@ -8,19 +8,22 @@
 
 #include "Timer.h"
 
-void Timer::start(const chrono::milliseconds interval, const Callback &callback) {
-    {
-        running = true;
-        th = thread([=]()
-                    {
-                        while (running == true) {
-                            this_thread::sleep_for(interval);
-                            callback();
-                        }
-                    });
+namespace XPC {
+    void Timer::start(const chrono::milliseconds interval, const Callback &callback) {
+        {
+            running = true;
+            th = thread([=]()
+                        {
+                            while (running == true) {
+                                this_thread::sleep_for(interval);
+                                callback();
+                            }
+                        });
+        }
     }
-}
-
-void Timer::stop() {
-    running = false;
+    
+    void Timer::stop() {
+        running = false;
+        th.join();
+    }
 }

--- a/xpcPlugin/Timer.h
+++ b/xpcPlugin/Timer.h
@@ -16,18 +16,20 @@
 
 using namespace std;
 
-class Timer
-{
-    
-    bool running = false;
-
-public:
-    thread th;
-    typedef std::function<void(void)> Callback;
-
-    void start(const chrono::milliseconds, const Callback &callback);
-
-    void stop();
-};
+namespace XPC {
+    class Timer
+    {
+        
+        bool running = false;
+        
+    public:
+        thread th;
+        typedef std::function<void(void)> Callback;
+        
+        void start(const chrono::milliseconds, const Callback &callback);
+        
+        void stop();
+    };
+}
 
 #endif /* Timer_hpp */

--- a/xpcPlugin/Timer.h
+++ b/xpcPlugin/Timer.h
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <thread>
 #include <chrono>
+#include <functional>
 
 using namespace std;
 

--- a/xpcPlugin/Timer.h
+++ b/xpcPlugin/Timer.h
@@ -1,10 +1,5 @@
-//
-//  Timer.hpp
-//  Thread
-//
-//  Created by Jan Chaloupecky on 16.12.18.
-//  Copyright © 2018 Jan Chaloupecky. All rights reserved.
-//
+// Copyright (c) 2013-2018 United States Government as represented by the Administrator of the
+// National Aeronautics and Space Administration. All Rights Reserved.
 
 #ifndef Timer_hpp
 #define Timer_hpp

--- a/xpcPlugin/Timer.h
+++ b/xpcPlugin/Timer.h
@@ -10,8 +10,6 @@
 #include <chrono>
 #include <functional>
 
-using namespace std;
-
 namespace XPC {
     class Timer
     {
@@ -19,10 +17,10 @@ namespace XPC {
         bool running = false;
         
     public:
-        thread th;
+        std::thread th;
         typedef std::function<void(void)> Callback;
         
-        void start(const chrono::milliseconds, const Callback &callback);
+        void start(const std::chrono::milliseconds, const Callback &callback);
         
         void stop();
     };

--- a/xpcPlugin/Timer.h
+++ b/xpcPlugin/Timer.h
@@ -1,8 +1,8 @@
 // Copyright (c) 2013-2018 United States Government as represented by the Administrator of the
 // National Aeronautics and Space Administration. All Rights Reserved.
 
-#ifndef Timer_hpp
-#define Timer_hpp
+#ifndef XPCPLUGIN_TIMER_H_
+#define XPCPLUGIN_TIMER_H_
 
 #include <stdio.h>
 #include <iostream>
@@ -12,13 +12,13 @@
 
 namespace XPC {
     class Timer
-    {
-        
-        bool running = false;
+    {        
+        std::atomic_flag running;
+        std::thread th;
         
     public:
-        std::thread th;
-        typedef std::function<void(void)> Callback;
+
+        using Callback = std::function<void(void)>;
         
         void start(const std::chrono::milliseconds, const Callback &callback);
         

--- a/xpcPlugin/Timer.h
+++ b/xpcPlugin/Timer.h
@@ -1,0 +1,33 @@
+//
+//  Timer.hpp
+//  Thread
+//
+//  Created by Jan Chaloupecky on 16.12.18.
+//  Copyright © 2018 Jan Chaloupecky. All rights reserved.
+//
+
+#ifndef Timer_hpp
+#define Timer_hpp
+
+#include <stdio.h>
+#include <iostream>
+#include <thread>
+#include <chrono>
+
+using namespace std;
+
+class Timer
+{
+    
+    bool running = false;
+
+public:
+    thread th;
+    typedef std::function<void(void)> Callback;
+
+    void start(const chrono::milliseconds, const Callback &callback);
+
+    void stop();
+};
+
+#endif /* Timer_hpp */

--- a/xpcPlugin/UDPSocket.cpp
+++ b/xpcPlugin/UDPSocket.cpp
@@ -139,7 +139,7 @@ namespace XPC
 		}
 	}
     
-    sockaddr* UDPSocket::GetAddr(std::string address, uint port)
+    sockaddr* UDPSocket::GetAddr(std::string address, unsigned short port)
     {
         struct sockaddr_in sa;
         inet_pton(AF_INET, address.c_str(), &(sa.sin_addr));

--- a/xpcPlugin/UDPSocket.cpp
+++ b/xpcPlugin/UDPSocket.cpp
@@ -139,13 +139,16 @@ namespace XPC
 		}
 	}
     
-    sockaddr* UDPSocket::GetAddr(std::string address, unsigned short port)
+    sockaddr UDPSocket::GetAddr(std::string address, unsigned short port)
     {
-        struct sockaddr_in sa;
-        inet_pton(AF_INET, address.c_str(), &(sa.sin_addr));
-        sa.sin_port = htons(port);
-        sockaddr* addr = (sockaddr*)&sa;
-        return addr;
+        struct sockaddr_in addr;
+        memset(&addr, 0, sizeof(addr));
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = inet_addr(address.c_str());
+        addr.sin_port = htons(port);
+
+        sockaddr* sa = reinterpret_cast<sockaddr*>(&addr);
+        return *sa;
     }
 
 	std::string UDPSocket::GetHost(sockaddr* sa)

--- a/xpcPlugin/UDPSocket.cpp
+++ b/xpcPlugin/UDPSocket.cpp
@@ -138,6 +138,15 @@ namespace XPC
 			Log::FormatLine(LOG_INFO, tag, "Send succeeded. (remote: %s)", GetHost(remote).c_str());
 		}
 	}
+    
+    sockaddr* UDPSocket::GetAddr(std::string address, uint port)
+    {
+        struct sockaddr_in sa;
+        inet_pton(AF_INET, address.c_str(), &(sa.sin_addr));
+        sa.sin_port = htons(port);
+        sockaddr* addr = (sockaddr*)&sa;
+        return addr;
+    }
 
 	std::string UDPSocket::GetHost(sockaddr* sa)
 	{

--- a/xpcPlugin/UDPSocket.h
+++ b/xpcPlugin/UDPSocket.h
@@ -56,12 +56,14 @@ namespace XPC
 		/// \param len    The number of bytes to send.
 		/// \param remote The destination socket.
 		void SendTo(const unsigned char* buffer, std::size_t len, sockaddr* remote) const;
-
+        
 		/// Gets a string containing the IP address and port contained in the given sockaddr.
 		///
 		/// \param addr The socket address to parse.
 		/// \returns    A string representation of the socket address.
 		static std::string GetHost(sockaddr* addr);
+        
+        sockaddr* GetAddr(std::string address, uint port);
 	private:
 #ifdef _WIN32
 		SOCKET sock;

--- a/xpcPlugin/UDPSocket.h
+++ b/xpcPlugin/UDPSocket.h
@@ -63,7 +63,7 @@ namespace XPC
 		/// \returns    A string representation of the socket address.
 		static std::string GetHost(sockaddr* addr);
         
-        sockaddr* GetAddr(std::string address, unsigned short port);
+        static sockaddr GetAddr(std::string address, unsigned short port);
 	private:
 #ifdef _WIN32
 		SOCKET sock;

--- a/xpcPlugin/UDPSocket.h
+++ b/xpcPlugin/UDPSocket.h
@@ -63,7 +63,7 @@ namespace XPC
 		/// \returns    A string representation of the socket address.
 		static std::string GetHost(sockaddr* addr);
         
-        sockaddr* GetAddr(std::string address, uint port);
+        sockaddr* GetAddr(std::string address, unsigned short port);
 	private:
 #ifdef _WIN32
 		SOCKET sock;

--- a/xpcPlugin/XPCPlugin.cpp
+++ b/xpcPlugin/XPCPlugin.cpp
@@ -64,6 +64,7 @@
 
 // XPLM Includes
 #include "XPLMProcessing.h"
+#include "XPLMUtilities.h"
 
 // System Includes
 #include <cstdlib>
@@ -75,6 +76,8 @@
 
 #define RECVPORT 49009 // Port that the plugin receives commands on
 #define OPS_PER_CYCLE 20 // Max Number of operations per cycle
+
+#define XPC_PLUGIN_VERSION "1.3-rc.1"
 
 XPC::UDPSocket* sock = NULL;
 XPC::Timer* timer = NULL;
@@ -107,7 +110,7 @@ PLUGIN_API int XPluginStart(char* outName, char* outSig, char* outDesc)
 		1000000000.0;
 	}
 #endif
-	XPC::Log::Initialize("1.3-rc.1");
+	XPC::Log::Initialize(XPC_PLUGIN_VERSION);
 	XPC::Log::WriteLine(LOG_INFO, "EXEC", "Plugin Start");
 	XPC::DataManager::Initialize();
 
@@ -161,7 +164,13 @@ PLUGIN_API int XPluginEnable(void)
 	XPLMRegisterFlightLoopCallback(XPCFlightLoopCallback, interval, refcon);
 
 	
-	timer->start(chrono::milliseconds(1000), XPC::MessageHandlers::SendBeacon);
+	int xpVer;
+	XPLMGetVersions(&xpVer, NULL, NULL);
+	
+	timer->start(chrono::milliseconds(1000), [=]{
+		XPC::MessageHandlers::SendBeacon(XPC_PLUGIN_VERSION, xpVer);
+	});
+	
 
 	return 1;
 }

--- a/xpcPlugin/XPCPlugin.cpp
+++ b/xpcPlugin/XPCPlugin.cpp
@@ -170,7 +170,7 @@ PLUGIN_API int XPluginEnable(void)
 	XPLMGetVersions(&xpVer, NULL, NULL);
 	
 	timer->start(chrono::milliseconds(1000), [=]{
-		XPC::MessageHandlers::SendBeacon(XPC_PLUGIN_VERSION, xpVer);
+		XPC::MessageHandlers::SendBeacon(XPC_PLUGIN_VERSION, RECVPORT, xpVer);
 	});
 	
 

--- a/xpcPlugin/XPCPlugin.cpp
+++ b/xpcPlugin/XPCPlugin.cpp
@@ -79,6 +79,8 @@
 
 #define XPC_PLUGIN_VERSION "1.3-rc.1"
 
+using namespace std;
+
 XPC::UDPSocket* sock = NULL;
 XPC::Timer* timer = NULL;
 

--- a/xpcPlugin/XPCPlugin.cpp
+++ b/xpcPlugin/XPCPlugin.cpp
@@ -60,6 +60,7 @@
 #include "Log.h"
 #include "MessageHandlers.h"
 #include "UDPSocket.h"
+#include "Timer.h"
 
 // XPLM Includes
 #include "XPLMProcessing.h"
@@ -76,6 +77,8 @@
 #define OPS_PER_CYCLE 20 // Max Number of operations per cycle
 
 XPC::UDPSocket* sock = NULL;
+
+Timer timer;
 
 double start;
 double lap;
@@ -96,7 +99,7 @@ PLUGIN_API int XPluginStart(char* outName, char* outSig, char* outDesc)
 	strcpy(outDesc, "X Plane Communications Toolbox\nCopyright (c) 2013-2018 United States Government as represented by the Administrator of the National Aeronautics and Space Administration. All Rights Reserved.");
 
 #if (__APPLE__)
-	if ( abs(timeConvert) <= 1e-9 ) // is about 0
+	if ( timeConvert <= 1e-9 ) // is about 0
 	{
 		mach_timebase_info_data_t timeBase;
 		(void)mach_timebase_info(&timeBase);
@@ -151,6 +154,12 @@ PLUGIN_API int XPluginEnable(void)
 	float interval = -1; // Call every frame
 	void* refcon = NULL; // Don't pass anything to the callback directly
 	XPLMRegisterFlightLoopCallback(XPCFlightLoopCallback, interval, refcon);
+	
+	
+	timer.start(chrono::milliseconds(1000), []{
+		cout << "Send UDP" << endl;
+		XPC::MessageHandlers::SendBeacon();
+	});
 
 	return 1;
 }

--- a/xpcPlugin/xpcPlugin.xcodeproj/project.pbxproj
+++ b/xpcPlugin/xpcPlugin.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3D0F44CE21C6D3E7008A0655 /* Timer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D0F44CD21C6D3E7008A0655 /* Timer.cpp */; };
 		BE37D960187C8B0F0033B082 /* XPCPlugin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE37D95E187C8B0F0033B082 /* XPCPlugin.cpp */; };
 		BE8361EF18C5591C00E9C923 /* mac.xpl in CopyFiles */ = {isa = PBXBuildFile; fileRef = D607B19909A556E400699BC3 /* mac.xpl */; };
 		BEABAD371AE041A3007BA7DA /* DataManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BEABAD2B1AE041A3007BA7DA /* DataManager.cpp */; };
@@ -36,6 +37,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3D0F44CC21C6D3E7008A0655 /* Timer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Timer.h; sourceTree = "<group>"; };
+		3D0F44CD21C6D3E7008A0655 /* Timer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Timer.cpp; sourceTree = "<group>"; };
 		BE37D95E187C8B0F0033B082 /* XPCPlugin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = XPCPlugin.cpp; sourceTree = SOURCE_ROOT; usesTabs = 1; };
 		BEABAD2B1AE041A3007BA7DA /* DataManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DataManager.cpp; sourceTree = "<group>"; };
 		BEABAD2C1AE041A3007BA7DA /* DataManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DataManager.h; sourceTree = "<group>"; };
@@ -76,6 +79,7 @@
 		AC4E46B809C2E0B3006B7E1B /* src */ = {
 			isa = PBXGroup;
 			children = (
+				3D0F44CD21C6D3E7008A0655 /* Timer.cpp */,
 				BE37D95E187C8B0F0033B082 /* XPCPlugin.cpp */,
 				BEDC620218EDF1A7005DB364 /* xplaneConnect.c */,
 				BEABAD2B1AE041A3007BA7DA /* DataManager.cpp */,
@@ -91,6 +95,7 @@
 		BE953E0B1AEB183400CE4A8C /* inc */ = {
 			isa = PBXGroup;
 			children = (
+				3D0F44CC21C6D3E7008A0655 /* Timer.h */,
 				BEDC620318EDF1A7005DB364 /* xplaneConnect.h */,
 				BEABAD2C1AE041A3007BA7DA /* DataManager.h */,
 				BEABAD301AE041A3007BA7DA /* Drawing.h */,
@@ -190,6 +195,7 @@
 				BEDC620418EDF1A7005DB364 /* xplaneConnect.c in Sources */,
 				BEABAD371AE041A3007BA7DA /* DataManager.cpp in Sources */,
 				BEABAD391AE041A3007BA7DA /* Drawing.cpp in Sources */,
+				3D0F44CE21C6D3E7008A0655 /* Timer.cpp in Sources */,
 				BE37D960187C8B0F0033B082 /* XPCPlugin.cpp in Sources */,
 				BEABAD3F1AE0498D007BA7DA /* UDPSocket.cpp in Sources */,
 			);

--- a/xpcPlugin/xpcPlugin.xcodeproj/project.pbxproj
+++ b/xpcPlugin/xpcPlugin.xcodeproj/project.pbxproj
@@ -298,6 +298,7 @@
 		D607B19C09A556E400699BC3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_LINK_OBJC_RUNTIME = NO;
 				CLANG_WARN_CXX0X_EXTENSIONS = YES;
@@ -337,6 +338,7 @@
 		D607B19D09A556E400699BC3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_LINK_OBJC_RUNTIME = NO;
 				CLANG_WARN_CXX0X_EXTENSIONS = YES;
@@ -365,9 +367,7 @@
 					"$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData/xplaneConnect-asdjuezcjkhojuewbyxhyhabxfwc/Build/Products/Debug",
 				);
 				MACH_O_TYPE = mh_bundle;
-
 				ONLY_ACTIVE_ARCH = NO;
-
 				PRODUCT_NAME = mac;
 				SDKROOT = macosx;
 				STRIP_INSTALLED_PRODUCT = YES;

--- a/xpcPlugin/xpcPlugin/xpcPlugin.vcxproj
+++ b/xpcPlugin/xpcPlugin/xpcPlugin.vcxproj
@@ -206,6 +206,7 @@
     <ClInclude Include="..\Log.h" />
     <ClInclude Include="..\Message.h" />
     <ClInclude Include="..\MessageHandlers.h" />
+    <ClCompile Include="..\Timer.h" />
     <ClInclude Include="..\UDPSocket.h" />
   </ItemGroup>
   <ItemGroup>
@@ -214,6 +215,7 @@
     <ClCompile Include="..\Log.cpp" />
     <ClCompile Include="..\Message.cpp" />
     <ClCompile Include="..\MessageHandlers.cpp" />
+    <ClCompile Include="..\Timer.cpp" />
     <ClCompile Include="..\UDPSocket.cpp" />
     <ClCompile Include="..\XPCPlugin.cpp" />
   </ItemGroup>


### PR DESCRIPTION
Hi, 
as discussed in https://github.com/nasa/XPlaneConnect/issues/147, here is the implementation of the UDP discovery of the plugin.

The format of the UDP packet is:
```
4 bytes: BECN
1 byte: 0
2 bytes: XPlaneConnect server port e.g. '49009'
4 bytes: X-Plane version e.g. '11260'
null terminated string: XPlaneConnect plugin version e.g. '1.3-rc.1'
```

The changes are
- Use `C++11` needed by `<thread>`
- Added a helper `Timer` class that can run a callback every x milliseconds
- Start a timer in `XPluginEnable` to UDP multicast the `BECN` packet

Compiles fine on all platforms. I'll provide the binaries once this is reviewed.

What is not part of this pull request are the client side implementations but I believe this can be done separately.

Tested on macOS, Linux and Windows