### PR TITLE
Added X-Plane 11 compatibility to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ languages that interact with the plugin.
 #### Quick Start
 To get started using X-Plane Connect, do the following.
 
-1. Purchase and install X-Plane 9 or 10.
+1. Purchase and install X-Plane 9, 10 or 11.
 2. Copy the X-Plane Plugin folder (`xpcPlugin/XPlaneConnect`) to the plugin
 directory (`[X-Plane Directory]/Resources/plugins/`)
 3. Write some code using one of the clients to manipulate X-Plane data.
@@ -55,7 +55,7 @@ physics simulation engine.
 ### Compatibility
 XPC has been tested with the following software versions:
 * Windows: Vista, 7, & 8
-* Mac OSX: 10.8-10.11
+* Mac OSX: 10.8-10.14
 * Linux: Tested on Red Hat Enterprise Linux Workstation release 6.6
 * X-Plane: 9, 10 & 11
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ XPC has been tested with the following software versions:
 * Windows: Vista, 7, & 8
 * Mac OSX: 10.8-10.11
 * Linux: Tested on Red Hat Enterprise Linux Workstation release 6.6
-* X-Plane: 9 & 10
+* X-Plane: 9, 10 & 11
 
 ### Contributing
 All contributions are welcome! If you are having problems with the plugin, please
@@ -102,14 +102,14 @@ Software without restriction, including without limitation the rights to use,
 copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
 Software, and to permit persons to whom the Software is furnished to do so,
 subject to the following conditions:
- 
+
 * Redistributions of source code must retain the above copyright notice, this
   list of conditions and the following disclaimer.
 * Neither the names of the authors nor that of X-Plane or Laminar Research may
   be used to endorse or promote products derived from this software without
   specific prior written permission from the authors or Laminar Research,
   respectively.
- 
+
 X-Plane API SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE


### PR DESCRIPTION
I've been testing the currently available pre-built binaries on X-Plane 11 and they seem to work perfectly fine out of the box. For testing purpose I used a Python client.