### PR TITLE
Fixed Timer.h Visual Studio Item Type

### DIFF
--- a/xpcPlugin/xpcPlugin/xpcPlugin.vcxproj
+++ b/xpcPlugin/xpcPlugin/xpcPlugin.vcxproj
@@ -206,7 +206,7 @@
     <ClInclude Include="..\Log.h" />
     <ClInclude Include="..\Message.h" />
     <ClInclude Include="..\MessageHandlers.h" />
-    <ClCompile Include="..\Timer.h" />
+    <ClInclude Include="..\Timer.h" />
     <ClInclude Include="..\UDPSocket.h" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
A wrong `Timer.h` file type in Visual Studio was causing linker errors.

fix #166 