### PR TITLE
Make azure pipelines create draft releases

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -163,3 +163,4 @@ stages:
           tag: $(tagName)
           assets: '$(Build.ArtifactStagingDirectory)/$(xpcPackageName).zip'
           isPreRelease: true
+          isDraft: true


### PR DESCRIPTION
Azure pipelines releases will now be created as drafts so that I can edit the title and release notes before publishing.