### PR TITLE
POSI fixes

### DIFF
--- a/xpcPlugin/DataManager.cpp
+++ b/xpcPlugin/DataManager.cpp
@@ -668,6 +668,11 @@ namespace XPC
 			return;
 		}
 
+		if (IsDefault(pos[0]) && IsDefault(pos[1]) && IsDefault(pos[2]))
+		{
+			Log::WriteLine(LOG_INFO, "DMAN", "Skipped SetPosition. All values were default");
+			return;
+		}
 		if (IsDefault(pos[0]))
 		{
 			pos[0] = GetDouble(DREF_Latitude, aircraft);
@@ -718,6 +723,12 @@ namespace XPC
 			return;
 		}
 
+
+		if (IsDefault(orient[0]) && IsDefault(orient[1]) && IsDefault(orient[2]))
+		{
+			Log::WriteLine(LOG_INFO, "DMAN", "Skipped SetPosition. All values were default");
+			return;
+		}
 		if (IsDefault(orient[0]))
 		{
 			orient[0] = GetFloat(DREF_Pitch, aircraft);

--- a/xpcPlugin/Message.cpp
+++ b/xpcPlugin/Message.cpp
@@ -141,11 +141,25 @@ namespace XPC
 		else if (head == "POSI")
 		{
 			char aircraft = buffer[5];
-			float gear = *((float*)(buffer + 30));
-			float pos[3];
+			float gear;
+			double pos[3];
 			float orient[3];
-			memcpy(pos, buffer + 6, 12);
-			memcpy(orient, buffer + 18, 12);
+			if (size == 34) /* lat/lon/h as 32-bit float */
+			{
+				float posd_32[3];
+				memcpy(posd_32, buffer + 6, 12);
+				pos[0] = posd_32[0];
+				pos[1] = posd_32[1];
+				pos[2] = posd_32[2];
+				memcpy(orient, buffer + 18, 12);
+				memcpy(&gear, buffer + 30, 4);
+			}
+			else if (size == 46) /* lat/lon/h as 64-bit double */
+			{
+				memcpy(pos, buffer + 6, 24);
+				memcpy(orient, buffer + 30, 12);
+				memcpy(&gear, buffer + 42, 4);
+			}
 			ss << " AC:" << (int)aircraft;
 			ss << " Pos:(" << pos[0] << ' ' << pos[1] << ' ' << pos[2] << ") Orient:(";
 			ss << orient[0] << ' ' << orient[1] << ' ' << orient[2] << ") Gear:";


### PR DESCRIPTION
- Add check to `SetPosition` to return early if all values are defaults. (This might happen with a POSI command that specifies orientations but not positions)
- Add check to `SetOrientation` to return  early if all values are defaults
- Fix a bug in `HandlePosi` where the gear value was being read incorrectly
- Also updates the syntax for the position copy to something that's ARM compatible
- Fixes the code in `Message` to print the value of the POSI command