### PR TITLE
Terrain height probe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ out/
 # Internal Docs #
 #################
 Docs/~$Capability Matrix.xlsx
+*.xpl

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ stages:
         inputs:
           actions: 'build'
           scheme: ''
-          sdk: 'macosx10.15'
+          sdk: 'macosx10.14'
           configuration: 'Release'
           xcWorkspacePath: 'xpcPlugin/xpcPlugin.xcodeproj'
           xcodeVersion: 'default' # Options: 8, 9, 10, default, specifyPath

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ stages:
         inputs:
           actions: 'build'
           scheme: ''
-          sdk: 'macosx10.14'
+          sdk: 'macosx10.15'
           configuration: 'Release'
           xcWorkspacePath: 'xpcPlugin/xpcPlugin.xcodeproj'
           xcodeVersion: 'default' # Options: 8, 9, 10, default, specifyPath

--- a/xpcPlugin/Message.cpp
+++ b/xpcPlugin/Message.cpp
@@ -121,7 +121,7 @@ namespace XPC
 			}
 			Log::WriteLine(LOG_DEBUG, "DBUG", ss.str());
 		}
-		else if (head == "GETC" || head == "GETP")
+		else if (head == "GETC" || head == "GETP" || head == "GETT")
 		{
 			ss << " Aircraft:" << (int)buffer[5];
 			Log::WriteLine(LOG_DEBUG, "DBUG", ss.str());

--- a/xpcPlugin/MessageHandlers.cpp
+++ b/xpcPlugin/MessageHandlers.cpp
@@ -69,7 +69,7 @@ namespace XPC
 			handlers.insert(std::make_pair("VIEW", MessageHandlers::HandleView));
 			handlers.insert(std::make_pair("GETC", MessageHandlers::HandleGetC));
 			handlers.insert(std::make_pair("GETP", MessageHandlers::HandleGetP));
-			handlers.insert(std::make_pair("GETT", MessageHandlers::HandleGetT)); // terrain properties
+			handlers.insert(std::make_pair("GETT", MessageHandlers::HandleGetT));
 			// X-Plane data messages
 			handlers.insert(std::make_pair("DSEL", MessageHandlers::HandleXPlaneData));
 			handlers.insert(std::make_pair("USEL", MessageHandlers::HandleXPlaneData));
@@ -643,7 +643,10 @@ namespace XPC
 		unsigned char aircraft = buffer[5];
 		Log::FormatLine(LOG_TRACE, "GTER", "Getting terrain information for aircraft %u", aircraft);
 		
-		double loc[3], X, Y, Z;
+        double loc[3];
+        double X;
+        double Y;
+        double Z;
 		memcpy(loc, buffer + 6, 24);
 		
 		if(loc[0] == -998 || loc[1] == -998 || loc[2] == -998)
@@ -674,7 +677,9 @@ namespace XPC
 		int rc = XPLMProbeTerrainXYZ(Terrain_probe, X, Y, Z, &probe_data);
 		
 		// transform probe location to world coordinates
-		double lat, lon, alt;
+        double lat;
+        double lon;
+        double alt;
 		
 		if(rc == 0)
 		{

--- a/xpcPlugin/MessageHandlers.cpp
+++ b/xpcPlugin/MessageHandlers.cpp
@@ -8,20 +8,20 @@
 // including without limitation the rights to use, copy, modify, merge, publish, distribute,
 // sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions :
-//   * Redistributions of source code must retain the above copyright notice,
-//     this list of conditions and the following disclaimer.
-//   * Neither the names of the authors nor that of X - Plane or Laminar Research
-//     may be used to endorse or promote products derived from this software
-//     without specific prior written permission from the authors or
-//     Laminar Research, respectively.
+//	 * Redistributions of source code must retain the above copyright notice,
+//	   this list of conditions and the following disclaimer.
+//	 * Neither the names of the authors nor that of X - Plane or Laminar Research
+//	   may be used to endorse or promote products derived from this software
+//	   without specific prior written permission from the authors or
+//	   Laminar Research, respectively.
 #include "MessageHandlers.h"
 #include "DataManager.h"
 #include "Drawing.h"
 #include "Log.h"
 
 #include "XPLMUtilities.h"
+#include "XPLMScenery.h"
 #include "XPLMGraphics.h"
-
 
 #include <cmath>
 #include <cstring>
@@ -41,6 +41,9 @@ namespace XPC
 	UDPSocket* MessageHandlers::sock;
 
 	static sockaddr multicast_address = UDPSocket::GetAddr(MULTICAST_GROUP, MULITCAST_PORT);
+	
+	// define a static terrain probe handler (do not re-create probe for each query)
+	XPLMProbeRef Terrain_probe = nullptr;
 
 	void MessageHandlers::SetSocket(UDPSocket* socket)
 	{
@@ -66,6 +69,7 @@ namespace XPC
 			handlers.insert(std::make_pair("VIEW", MessageHandlers::HandleView));
 			handlers.insert(std::make_pair("GETC", MessageHandlers::HandleGetC));
 			handlers.insert(std::make_pair("GETP", MessageHandlers::HandleGetP));
+			handlers.insert(std::make_pair("GETT", MessageHandlers::HandleGetT)); // terrain properties
 			// X-Plane data messages
 			handlers.insert(std::make_pair("DSEL", MessageHandlers::HandleXPlaneData));
 			handlers.insert(std::make_pair("USEL", MessageHandlers::HandleXPlaneData));
@@ -626,6 +630,89 @@ namespace XPC
 			}
 		}
 	}
+	
+	void MessageHandlers::HandleGetT(const Message& msg)
+	{
+		const unsigned char* buffer = msg.GetBuffer();
+		std::size_t size = msg.GetSize();
+		if (size != 30)
+		{
+			Log::FormatLine(LOG_ERROR, "GTER", "Unexpected message length: %u", size);
+			return;
+		}
+		unsigned char aircraft = buffer[5];
+		Log::FormatLine(LOG_TRACE, "GTER", "Getting terrain information for aircraft %u", aircraft);
+		
+		double loc[3], X, Y, Z;
+		memcpy(loc, buffer + 6, 24);
+		
+		if(loc[0] == -998 || loc[1] == -998 || loc[2] == -998)
+		{
+			// get terrain properties at aircraft location
+			// probe needs to be below terrain to work...
+			X = DataManager::GetDouble(DREF_LocalX, aircraft);
+			Z = DataManager::GetDouble(DREF_LocalZ, aircraft);
+			Y = -100.0;
+		}
+		else
+		{
+			// terrain probe at specified location
+			XPLMWorldToLocal(loc[0], loc[1], loc[2], &X, &Y, &Z);
+		}
+		
+		// Init terrain probe (if required) and probe data struct
+		XPLMProbeInfo_t probe_data;
+		probe_data.structSize = sizeof(XPLMProbeInfo_t);
+		
+		if(Terrain_probe == nullptr)
+		{
+			Log::FormatLine(LOG_TRACE, "GTER", "Create terrain probe for aircraft %u", aircraft);
+			Terrain_probe = XPLMCreateProbe(0);
+		}
+		
+		// query probe
+		int rc = XPLMProbeTerrainXYZ(Terrain_probe, X, Y, Z, &probe_data);
+		
+		// transform probe location to world coordinates
+		double lat, lon, alt;
+		
+		if(rc == 0)
+		{
+			XPLMLocalToWorld(probe_data.locationX, probe_data.locationY, probe_data.locationZ, &lat, &lon, &alt);
+			
+			Log::FormatLine(LOG_TRACE, "GTER", "Probe LLA %lf %lf %lf", lat, lon, alt);
+		}
+		else
+		{
+			lat = -998;
+			lon = -998;
+			alt = -998;
+			
+			Log::FormatLine(LOG_TRACE, "GTER", "Probe failed. Return Value %u", rc);
+		}
+		
+		// keep probe for next query
+		// XPLMDestroyProbe(probe);
+		
+		// Assemble response message
+		unsigned char response[50] = "TERR";
+		response[5] = aircraft;
+		// terrain height over msl at lat/lon point
+		memcpy(response + 6,  &lat, 8);
+		memcpy(response + 14, &lon, 8);
+		memcpy(response + 22, &alt, 8);
+		// terrain incidence
+		memcpy(response + 30, &probe_data.normalX, 4);
+		memcpy(response + 34, &probe_data.normalY, 4);
+		memcpy(response + 38, &probe_data.normalZ, 4);
+		// terrain type
+		memcpy(response + 42, &probe_data.is_wet, 4);
+		// probe status
+		memcpy(response + 46, &rc, 4);
+		
+		sock->SendTo(response, 50, &connection.addr);
+	}
+
 
 	void MessageHandlers::HandleSimu(const Message& msg)
 	{
@@ -798,7 +885,7 @@ namespace XPC
 				double dy = y - cY;
 				double dz = z - cZ;
 
-//			    Log::FormatLine(LOG_TRACE, "CAM", "Cam vect %f %f %f", dx, dy, dz);
+//				Log::FormatLine(LOG_TRACE, "CAM", "Cam vect %f %f %f", dx, dy, dz);
 
 				double pi = 3.141592653589793;
 
@@ -811,15 +898,15 @@ namespace XPC
 
 				outCameraPosition->heading = 90 + angle; // rel to north
 
-//			    Log::FormatLine(LOG_TRACE, "CAM", "Cam p %f hdg %f ", outCameraPosition->pitch, outCameraPosition->heading);
+//				Log::FormatLine(LOG_TRACE, "CAM", "Cam p %f hdg %f ", outCameraPosition->pitch, outCameraPosition->heading);
 
 				outCameraPosition->roll = 0;
 			}
 			else
 			{
-				outCameraPosition->roll     = campos->direction[0];
-				outCameraPosition->pitch    = campos->direction[1];
-				outCameraPosition->heading  = campos->direction[2];
+				outCameraPosition->roll		= campos->direction[0];
+				outCameraPosition->pitch	= campos->direction[1];
+				outCameraPosition->heading	= campos->direction[2];
 			}
 
 			outCameraPosition->zoom = campos->zoom;

--- a/xpcPlugin/MessageHandlers.cpp
+++ b/xpcPlugin/MessageHandlers.cpp
@@ -637,11 +637,11 @@ namespace XPC
 		std::size_t size = msg.GetSize();
 		if (size != 30)
 		{
-			Log::FormatLine(LOG_ERROR, "GTER", "Unexpected message length: %u", size);
+			Log::FormatLine(LOG_ERROR, "GETT", "Unexpected message length: %u", size);
 			return;
 		}
 		unsigned char aircraft = buffer[5];
-		Log::FormatLine(LOG_TRACE, "GTER", "Getting terrain information for aircraft %u", aircraft);
+		Log::FormatLine(LOG_TRACE, "GETT", "Getting terrain information for aircraft %u", aircraft);
 		
         double loc[3];
         double X;
@@ -669,7 +669,7 @@ namespace XPC
 		
 		if(Terrain_probe == nullptr)
 		{
-			Log::FormatLine(LOG_TRACE, "GTER", "Create terrain probe for aircraft %u", aircraft);
+			Log::FormatLine(LOG_TRACE, "GETT", "Create terrain probe for aircraft %u", aircraft);
 			Terrain_probe = XPLMCreateProbe(0);
 		}
 		
@@ -685,7 +685,7 @@ namespace XPC
 		{
 			XPLMLocalToWorld(probe_data.locationX, probe_data.locationY, probe_data.locationZ, &lat, &lon, &alt);
 			
-			Log::FormatLine(LOG_TRACE, "GTER", "Probe LLA %lf %lf %lf", lat, lon, alt);
+			Log::FormatLine(LOG_TRACE, "GETT", "Probe LLA %lf %lf %lf", lat, lon, alt);
 		}
 		else
 		{
@@ -693,7 +693,7 @@ namespace XPC
 			lon = -998;
 			alt = -998;
 			
-			Log::FormatLine(LOG_TRACE, "GTER", "Probe failed. Return Value %u", rc);
+			Log::FormatLine(LOG_TRACE, "GETT", "Probe failed. Return Value %u", rc);
 		}
 		
 		// keep probe for next query

--- a/xpcPlugin/MessageHandlers.h
+++ b/xpcPlugin/MessageHandlers.h
@@ -56,6 +56,7 @@ namespace XPC
 		static void HandleText(const Message& msg);
 		static void HandleWypt(const Message& msg);
 		static void HandleView(const Message& msg);
+		static void HandleGetT(const Message& msg);
 
 		static void HandleXPlaneData(const Message& msg);
 		static void HandleUnknown(const Message& msg);

--- a/xpcPlugin/xpcPlugin.xcodeproj/project.pbxproj
+++ b/xpcPlugin/xpcPlugin.xcodeproj/project.pbxproj
@@ -230,6 +230,10 @@
 				MACH_O_TYPE = mh_bundle;
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-DXPLM200",
+				);
 				OTHER_LDFLAGS = (
 					"$(OTHER_LDFLAGS)",
 					"-Wl,-exported_symbol",
@@ -278,6 +282,10 @@
 				);
 				MACH_O_TYPE = mh_bundle;
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-DXPLM200",
+				);
 				OTHER_LDFLAGS = (
 					"$(OTHER_LDFLAGS)",
 					"-Wl,-exported_symbol",


### PR DESCRIPTION
This adds the capability to obtain the terrain height above MSL at a given location using a XPLM terrain probe. A new message pair (GETT query, terrain response) was added to specify the probe location and to return the data.

The probe is persistent once created for speed. Currently only one probe is supported.

Using this mechanism allows to land an aircraft onto the x-plane world.

Definitions for the message formats will be added shortly. 