### PR TITLE
Get double posi

### DIFF
--- a/C/monitorExample/main.c
+++ b/C/monitorExample/main.c
@@ -55,7 +55,6 @@ struct timeval tv;
 
 int waitForInput()
 {
-
 	FD_ZERO(&fds);
 	FD_SET(fdstdin, &fds);
 	select(1, &fds, NULL, NULL, &tv);
@@ -70,7 +69,7 @@ int main(void)
     tv.tv_usec = 100 * 1000;
 	while (1)
 	{
-		float posi[7]; // FIXME: change this to the 64-bit lat/lon/h
+		double posi[7]; // FIXME: change this to the 64-bit lat/lon/h
 		int result = getPOSI(client, posi, aircraftNum);
 		if (result < 0) // Error in getPOSI
 		{
@@ -84,7 +83,7 @@ int main(void)
 			break;
 		}
 
-		printf("Loc: (%4f, %4f, %4f) Aileron:%2f Elevator:%2f Rudder:%2f\n",
+		printf("Loc: (%4lf, %4lf, %4lf) Aileron:%2f Elevator:%2f Rudder:%2f\n",
 			posi[0], posi[1], posi[2], ctrl[1], ctrl[0], ctrl[2]);
 
 		// Check if any key has been pressed and break

--- a/C/playbackExample/src/playback.c
+++ b/C/playbackExample/src/playback.c
@@ -62,17 +62,17 @@ void record(char* path, int interval, int duration)
 	}
 	displayMsg("Recording...");
 
-	XPCSocket sock = openUDP("127.0.0.1");
+	XPCSocket sock = openUDP("192.168.1.210");
 	for (int i = 0; i < count; ++i)
 	{
-		float posi[7];
+		double posi[7];
 		int result = getPOSI(sock, posi, 0);
 		playbackSleep(interval);
 		if (result < 0)
 		{
 			continue;
 		}
-		fprintf(fd, "%f, %f, %f, %f, %f, %f, %f\n", posi[0], posi[1], posi[2], posi[3], posi[4], posi[5], posi[6]);
+		fprintf(fd, "%.10lf, %.10lf, %.10lf, %lf, %lf, %lf, %lf\n", posi[0], posi[1], posi[2], posi[3], posi[4], posi[5], posi[6]);
 	}
 	closeUDP(sock);
 	displayMsg("Recording Complete");
@@ -88,8 +88,9 @@ void playback(char* path, int interval)
 	}
 	displayMsg("Starting Playback...");
 
-	XPCSocket sock = openUDP("127.0.0.1");
+	XPCSocket sock = openUDP("192.168.1.210");
 	double posi[7];
+	pauseSim(sock, 1);
 	while (!feof(fd) && !ferror(fd))
 	{
 		int result = fscanf(fd, "%lf, %lf, %lf, %lf, %lf, %lf, %lf\n",
@@ -101,6 +102,7 @@ void playback(char* path, int interval)
 		}
 		sendPOSI(sock, posi, 7, 0);
 	}
+	pauseSim(sock, 0);
 	closeUDP(sock);
 	displayMsg("Playback Complete");
 }

--- a/C/playbackExample/src/playback.c
+++ b/C/playbackExample/src/playback.c
@@ -62,7 +62,7 @@ void record(char* path, int interval, int duration)
 	}
 	displayMsg("Recording...");
 
-	XPCSocket sock = openUDP("192.168.1.210");
+	XPCSocket sock = openUDP("localhost");
 	for (int i = 0; i < count; ++i)
 	{
 		double posi[7];
@@ -72,7 +72,8 @@ void record(char* path, int interval, int duration)
 		{
 			continue;
 		}
-		fprintf(fd, "%.10lf, %.10lf, %.10lf, %lf, %lf, %lf, %lf\n", posi[0], posi[1], posi[2], posi[3], posi[4], posi[5], posi[6]);
+		fprintf(fd, "%.10lf, %.10lf, %.10lf, %lf, %lf, %lf, %lf\n",
+			posi[0], posi[1], posi[2], posi[3], posi[4], posi[5], posi[6]);
 	}
 	closeUDP(sock);
 	displayMsg("Recording Complete");
@@ -88,7 +89,7 @@ void playback(char* path, int interval)
 	}
 	displayMsg("Starting Playback...");
 
-	XPCSocket sock = openUDP("192.168.1.210");
+	XPCSocket sock = openUDP("localhost");
 	double posi[7];
 	pauseSim(sock, 1);
 	while (!feof(fd) && !ferror(fd))

--- a/C/src/xplaneConnect.c
+++ b/C/src/xplaneConnect.c
@@ -565,23 +565,16 @@ int getPOSI(XPCSocket sock, double values[7], char ac)
 	}
 
 	// Copy response into values
-	//memcpy(values, readBuffer + 6, 7 * sizeof(float));
-	float temp_val[4];
-
 	memcpy(values, readBuffer + 6, 3 * sizeof(double));
+
+	float temp_val[4];
 	memcpy(&temp_val, readBuffer + 30, 4 * sizeof(float));
 
 	int i = 0;
 	for(i = 0; i < 4; i++)
 	{
 		values[i + 3] = (double)temp_val[i];
-		printf("float = %f || double = %lf \n", temp_val[i], values[i + 3]);
 	}
-
-	// memcpy(&values[3], readBuffer + 30, sizeof(float));
-	// memcpy(&values[4], readBuffer + 34, sizeof(float));
-	// memcpy(&values[5], readBuffer + 38, sizeof(float));
-	// memcpy(&values[6], readBuffer + 42, sizeof(float));
 
 	return 0;
 }

--- a/C/src/xplaneConnect.c
+++ b/C/src/xplaneConnect.c
@@ -537,7 +537,7 @@ int getDREFs(XPCSocket sock, const char* drefs[], float* values[], unsigned char
 /*****************************************************************************/
 /****                          POSI functions                             ****/
 /*****************************************************************************/
-int getPOSI(XPCSocket sock, float values[7], char ac)
+int getPOSI(XPCSocket sock, double values[7], char ac)
 {
 	// Setup send command
 	unsigned char buffer[6] = "GETP";
@@ -551,22 +551,38 @@ int getPOSI(XPCSocket sock, float values[7], char ac)
 	}
 
 	// Get response
-	unsigned char readBuffer[34];
-	int readResult = readUDP(sock, readBuffer, 34);
+	unsigned char readBuffer[46];
+	int readResult = readUDP(sock, readBuffer, 46);
 	if (readResult < 0)
 	{
 		printError("getPOSI", "Failed to read response.");
 		return -2;
 	}
-	if (readResult != 34)
+	if (readResult != 46)
 	{
 		printError("getPOSI", "Unexpected response length.");
 		return -3;
 	}
-    // TODO: change this to the 64-bit lat/lon/h
 
 	// Copy response into values
-	memcpy(values, readBuffer + 6, 7 * sizeof(float));
+	//memcpy(values, readBuffer + 6, 7 * sizeof(float));
+	float temp_val[4];
+
+	memcpy(values, readBuffer + 6, 3 * sizeof(double));
+	memcpy(&temp_val, readBuffer + 30, 4 * sizeof(float));
+
+	int i = 0;
+	for(i = 0; i < 4; i++)
+	{
+		values[i + 3] = (double)temp_val[i];
+		printf("float = %f || double = %lf \n", temp_val[i], values[i + 3]);
+	}
+
+	// memcpy(&values[3], readBuffer + 30, sizeof(float));
+	// memcpy(&values[4], readBuffer + 34, sizeof(float));
+	// memcpy(&values[5], readBuffer + 38, sizeof(float));
+	// memcpy(&values[6], readBuffer + 42, sizeof(float));
+
 	return 0;
 }
 

--- a/C/src/xplaneConnect.h
+++ b/C/src/xplaneConnect.h
@@ -202,7 +202,7 @@ int getDREFs(XPCSocket sock, const char* drefs[], float* values[], unsigned char
 /// \param values An array to store the position information returned by the
 ///               plugin. The format of values is [Lat, Lon, Alt, Pitch, Roll, Yaw, Gear]
 /// \returns      0 if successful, otherwise a negative value.
-int getPOSI(XPCSocket sock, float values[7], char ac);
+int getPOSI(XPCSocket sock, double values[7], char ac);
 
 /// Sets the position and orientation of the specified aircraft.
 ///

--- a/Java/Examples/ContinuousOperation/src/Main.java
+++ b/Java/Examples/ContinuousOperation/src/Main.java
@@ -20,7 +20,7 @@ public class Main
             int aircraft = 0;
             while(true)
             {
-                float[] posi = xpc.getPOSI(aircraft); // FIXME: change this to 64-bit double
+                double[] posi = xpc.getPOSI(aircraft); // FIXME: change this to 64-bit double
                 float[] ctrl = xpc.getCTRL(aircraft);
 
                 System.out.format("Loc: (%4f, %4f, %4f) Aileron:%2f Elevator:%2f Rudder:%2f\n",

--- a/Java/Examples/Playback/src/gov/nasa/xpc/Main.java
+++ b/Java/Examples/Playback/src/gov/nasa/xpc/Main.java
@@ -99,7 +99,7 @@ public class Main
             {
                 for (int i = 0; i < count; ++i)
                 {
-                    float[] posi = xpc.getPOSI(0); // FIXME: change this to 64-bit double
+                    double[] posi = xpc.getPOSI(0);
                     writer.write(String.format("%1$f, %2$f, %3$f, %4$f, %5$f, %6$f, %7$f\n",
                             posi[0], posi[1], posi[2], posi[3], posi[4], posi[5], posi[6]));
                     try

--- a/Java/src/XPlaneConnect.java
+++ b/Java/src/XPlaneConnect.java
@@ -579,7 +579,7 @@ public class XPlaneConnect implements AutoCloseable
         {
             throw new IOException("No response received.");
         }
-        if(data.length < 34)
+        if(data.length < 46)
         {
             throw new IOException("Response too short");
         }
@@ -588,9 +588,18 @@ public class XPlaneConnect implements AutoCloseable
         double[] result = new double[7];
         ByteBuffer bb = ByteBuffer.wrap(data);
         bb.order(ByteOrder.LITTLE_ENDIAN);
+        int j = 0;
         for(int i = 0; i < 7; ++i)
         {
-            result[i] = bb.getFloat(6 + 4 * i);
+            if(i < 3)
+            {
+                result[i] = bb.getDouble(6 + 8 * i);
+            }
+            else
+            {
+                result[i] = bb.getFloat(30 + 4 * j)
+                j = j + 1
+            }
         }
         return result;
     }

--- a/Python/src/playbackExample.py
+++ b/Python/src/playbackExample.py
@@ -13,12 +13,13 @@ def record(path, interval = 0.1, duration = 60):
         print "duration is less than a single frame."
         return
 
-    with xpc.XPlaneConnect("192.168.1.210", 49009, 0, 1000) as client:
+    with xpc.XPlaneConnect("localhost", 49009, 0, 1000) as client:
         print "Recording..."
         for i in range(0, count):
             try:
                 posi = client.getPOSI()
-                fd.write("{0}, {1}, {2}, {3}, {4}, {5}, {6}\n".format(*posi))
+                data_template = "{:.10f}, {:.10f}, {:.10f}, {}, {}, {}, {}\n"
+                fd.write(data_template.format(*posi))
             except:
                 print "Error reading position"
                 continue
@@ -33,7 +34,7 @@ def playback(path, interval):
         print "Unable to open file."
         return
 
-    with xpc.XPlaneConnect("192.168.1.210", 49009, 0, 1000) as client:
+    with xpc.XPlaneConnect("localhost", 49009, 0, 1000) as client:
         print "Starting Playback..."
         for line in fd:
             try:

--- a/Python/src/playbackExample.py
+++ b/Python/src/playbackExample.py
@@ -13,7 +13,7 @@ def record(path, interval = 0.1, duration = 60):
         print "duration is less than a single frame."
         return
 
-    with xpc.XPlaneConnect("localhost", 49009, 0, 1000) as client:
+    with xpc.XPlaneConnect("192.168.1.210", 49009, 0, 1000) as client:
         print "Recording..."
         for i in range(0, count):
             try:
@@ -33,7 +33,7 @@ def playback(path, interval):
         print "Unable to open file."
         return
 
-    with xpc.XPlaneConnect("localhost", 49009, 0, 1000) as client:
+    with xpc.XPlaneConnect("192.168.1.210", 49009, 0, 1000) as client:
         print "Starting Playback..."
         for line in fd:
             try:

--- a/Python/src/xpc.py
+++ b/Python/src/xpc.py
@@ -158,10 +158,10 @@ class XPlaneConnect(object):
 
         # Read response
         resultBuf = self.readUDP()
-        if len(resultBuf) != 34:
+        if len(resultBuf) != 46:
             raise ValueError("Unexpected response length.")
 
-        result = struct.unpack("<4sxBfffffff", resultBuf)
+        result = struct.unpack("<4sxBdddffff", resultBuf)
         if result[0] != "POSI":
             raise ValueError("Unexpected header: " + result[0])
 
@@ -191,14 +191,12 @@ class XPlaneConnect(object):
         if ac < 0 or ac > 20:
             raise ValueError("Aircraft number must be between 0 and 20.")
 
-        # FIXME update this to the 64-bit double lat/lon/h
         # Pack message
         buffer = struct.pack("<4sxB", "POSI", ac)
         for i in range(7):
-            val = -998
-            if i < len(values):
-                val = values[i]
-            buffer += struct.pack("<f", val)
+            val = values[i] if i < len(values) else -988
+            val_type = "d" if i < 3 else "f"
+            buffer += struct.pack("<{}".format(val_type), val)
 
         # Send
         self.sendUDP(buffer)

--- a/Python3/src/playbackExample.py
+++ b/Python3/src/playbackExample.py
@@ -18,7 +18,8 @@ def record(path, interval = 0.1, duration = 60):
         for i in range(0, count):
             try:
                 posi = client.getPOSI()
-                fd.write("{0}, {1}, {2}, {3}, {4}, {5}, {6}\n".format(*posi))
+                data_template = "{:.10f}, {:.10f}, {:.10f}, {}, {}, {}, {}\n"
+                fd.write(data_template.format(*posi))
             except:
                 print "Error reading position"
                 continue

--- a/Python3/src/xpc.py
+++ b/Python3/src/xpc.py
@@ -161,7 +161,7 @@ class XPlaneConnect(object):
         if len(resultBuf) != 34:
             raise ValueError("Unexpected response length.")
 
-        result = struct.unpack(b"<4sxBfffffff", resultBuf)
+        result = struct.unpack(b"<4sxBdddffff", resultBuf)
         if result[0] != b"POSI":
             raise ValueError("Unexpected header: " + result[0])
 
@@ -194,10 +194,9 @@ class XPlaneConnect(object):
         # Pack message
         buffer = struct.pack(b"<4sxB", b"POSI", ac)
         for i in range(7):
-            val = -998
-            if i < len(values):
-                val = values[i]
-            buffer += struct.pack(b"<f", val)
+            val = values[i] if i < len(values) else -988
+            val_type = "d" if i < 3 else "f"
+            buffer += struct.pack(f"<{val_type}", val)
 
         # Send
         self.sendUDP(buffer)

--- a/TestScripts/C Tests/CMakeLists.txt
+++ b/TestScripts/C Tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 2.8.4)
+
+project(ctest)
+
+file(GLOB SOURCES "./*.c")
+add_executable(main ${SOURCES})
+
+include_directories(/usr/local/include/xplaneConnect)
+
+find_library(XPLANECONNECT_LIB NAMES xplaneconnect PATHS "/usr/local/lib")
+
+message(STATUS "Library path XPLANECONNECT_LIB is " ${XPLANECONNECT_LIB})
+
+target_link_libraries(main ${XPLANECONNECT_LIB})
+
+set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)

--- a/TestScripts/C Tests/PosiTests.h
+++ b/TestScripts/C Tests/PosiTests.h
@@ -43,7 +43,7 @@ int doPOSITest(char* drefs[7], double values[], int size, int ac, double expecte
 int doGETPTest(double values[7], int ac, double expected[7])
 {
 	// Execute Test
-	float actual[7];
+	double actual[7];
 	XPCSocket sock = openUDP(IP);
 	int result = sendPOSI(sock, values, 7, ac);
 	if (result >= 0)

--- a/xpcPlugin/MessageHandlers.cpp
+++ b/xpcPlugin/MessageHandlers.cpp
@@ -554,21 +554,21 @@ namespace XPC
 		unsigned char aircraft = buffer[5];
 		Log::FormatLine(LOG_TRACE, "GPOS", "Getting position information for aircraft %u", aircraft);
 
-		unsigned char response[34] = "POSI";
+		unsigned char response[46] = "POSI";
 		response[5] = (char)DataManager::GetInt(DREF_GearHandle, aircraft);
 		// TODO change lat/lon/h to double?
-		*((float*)(response + 6)) = (float)DataManager::GetDouble(DREF_Latitude, aircraft);
-		*((float*)(response + 10)) = (float)DataManager::GetDouble(DREF_Longitude, aircraft);
-		*((float*)(response + 14)) = (float)DataManager::GetDouble(DREF_Elevation, aircraft);
-		*((float*)(response + 18)) = DataManager::GetFloat(DREF_Pitch, aircraft);
-		*((float*)(response + 22)) = DataManager::GetFloat(DREF_Roll, aircraft);
-		*((float*)(response + 26)) = DataManager::GetFloat(DREF_HeadingTrue, aircraft);
+		*((double*)(response + 6)) = DataManager::GetDouble(DREF_Latitude, aircraft);
+		*((double*)(response + 14)) = DataManager::GetDouble(DREF_Longitude, aircraft);
+		*((double*)(response + 22)) = DataManager::GetDouble(DREF_Elevation, aircraft);
+		*((float*)(response + 30)) = DataManager::GetFloat(DREF_Pitch, aircraft);
+		*((float*)(response + 34)) = DataManager::GetFloat(DREF_Roll, aircraft);
+		*((float*)(response + 38)) = DataManager::GetFloat(DREF_HeadingTrue, aircraft);
 
 		float gear[10];
 		DataManager::GetFloatArray(DREF_GearDeploy, gear, 10, aircraft);
-		*((float*)(response + 30)) = gear[0];
+		*((float*)(response + 42)) = gear[0];
 
-		sock->SendTo(response, 34, &connection.addr);
+		sock->SendTo(response, 46, &connection.addr);
 	}
 
 	void MessageHandlers::HandlePosi(const Message& msg)


### PR DESCRIPTION
# Overview
Updated the XPlaneConnect Plugin and APIs (Java, Matlab, Python and C) to deal with latitude, longitude and altitude positions in double precision float format. The tests for the C and Python API were updated as well.

# Caution
* I did not test the Java and Matlab APIs but I modified them to make them work with the double precision format (in theory) and they should be working normally. (Sorry about that)
* This update of the the APIs and plugins is not backwards compatible with the old versions, since the values sent for latitude, longitude and altitude will be in double precision floats.

# PS
If you prefere I could create a new function similar to the one that returns the position and orientation in 32bit floats to handle doubles (both in the plugin and in the APIs). This way the backwards compatibility would be maintained.