### PR TITLE
Created sendPOST function that combines functions of sendPOSI and getTERR

### DIFF
--- a/C/src/xplaneConnect.c
+++ b/C/src/xplaneConnect.c
@@ -692,28 +692,6 @@ int getTERRResponse(XPCSocket sock, double values[11], char ac)
 	return 0;
 }
 
-int getTERR(XPCSocket sock, double posi[3], double values[11], char ac)
-{
-	// Send Command
-	int result = sendTERRRequest(sock, posi, ac);
-	if (result < 0)
-	{
-		// An error ocurred while sending.
-		// sendTERRRequest will print an error message, so just return.
-		return result;
-	}
-
-	// Read Response
-	result = getTERRResponse(sock, values, ac);
-	if (result < 0)
-	{
-		// An error ocurred while reading the response.
-		// getTERRResponse will print an error message, so just return.
-		return result;
-	}
-	return 0;
-}
-
 int sendPOST(XPCSocket sock, double posi[], int size, double values[11], char ac)
 {
 	// Validate input
@@ -765,6 +743,28 @@ int sendPOST(XPCSocket sock, double posi[], int size, double values[11], char ac
 	if (result < 0)
 	{
 		// A error ocurred while reading the response.
+		// getTERRResponse will print an error message, so just return.
+		return result;
+	}
+	return 0;
+}
+
+int getTERR(XPCSocket sock, double posi[3], double values[11], char ac)
+{
+	// Send Command
+	int result = sendTERRRequest(sock, posi, ac);
+	if (result < 0)
+	{
+		// An error ocurred while sending.
+		// sendTERRRequest will print an error message, so just return.
+		return result;
+	}
+
+	// Read Response
+	result = getTERRResponse(sock, values, ac);
+	if (result < 0)
+	{
+		// An error ocurred while reading the response.
 		// getTERRResponse will print an error message, so just return.
 		return result;
 	}

--- a/C/src/xplaneConnect.h
+++ b/C/src/xplaneConnect.h
@@ -159,7 +159,7 @@ int sendDREF(XPCSocket sock, const char* dref, float values[], int size);
 ///          the type described on the wiki. This doesn't cause any data loss for most datarefs.
 /// \param sock   The socket to use to send the command.
 /// \param drefs  The names of the datarefs to set.
-/// \param values A 2D array array containing the values for each dataref to set.
+/// \param values A 2D array containing the values for each dataref to set.
 /// \param sizes  The number of elements in each array in values
 /// \param count  The number of datarefs being set.
 /// \returns      0 if successful, otherwise a negative value.
@@ -208,7 +208,7 @@ int getPOSI(XPCSocket sock, double values[7], char ac);
 /// Sets the position and orientation of the specified aircraft.
 ///
 /// \param sock   The socket to use to send the command.
-/// \param values An array representing position data about the aircraft. The format of values is
+/// \param values A double array representing position data about the aircraft. The format of values is
 ///               [Lat, Lon, Alt, Pitch, Roll, Yaw, Gear]. If less than 7 values are specified,
 ///               the unspecified values will be left unchanged.
 /// \param size   The number of elements in values.
@@ -217,22 +217,6 @@ int getPOSI(XPCSocket sock, double values[7], char ac);
 int sendPOSI(XPCSocket sock, double values[], int size, char ac);
 
 // Terrain
-
-/// Gets the terrain information of the specified aircraft.
-///
-/// \param sock   The socket to use to send the command.
-/// \param posi   A double array representing position data about the aircraft. The format of values is
-///               [Lat, Lon, Alt].
-///               -998 used for [Lat, Lon, Alt] to request terrain info at the current aircraft position.
-/// \param values A double array with the information for the terrain output. The format of values is
-///               [Lat, Lon, Alt, Nx, Ny, Nz, Vx, Vy, Vz, wet, result]. The first three are for output of
-///               the Lat and Lon of the aircraft with the terrain height directly below. The next three
-///               represent the terrain normal. The next three represent the velocity of the terrain.
-///               The wet variable is 0.0 if the terrain is dry and 1.0 if wet.
-///               The last output is the terrain probe result parameter.
-/// \param ac     The aircraft number to get the terrain data of. 0 for the main/user's aircraft.
-/// \returns      0 if successful, otherwise a negative value.
-int getTERR(XPCSocket sock, double posi[3], double values[11], char ac);
 
 /// Sets the position and orientation and gets the terrain information of the specified aircraft.
 ///
@@ -250,6 +234,22 @@ int getTERR(XPCSocket sock, double posi[3], double values[11], char ac);
 /// \param ac     The aircraft number to set the position of. 0 for the main/user's aircraft.
 /// \returns      0 if successful, otherwise a negative value.
 int sendPOST(XPCSocket sock, double posi[], int size, double values[11], char ac);
+
+/// Gets the terrain information of the specified aircraft.
+///
+/// \param sock   The socket to use to send the command.
+/// \param posi   A double array representing position data about the aircraft. The format of values is
+///               [Lat, Lon, Alt].
+///               -998 used for [Lat, Lon, Alt] to request terrain info at the current aircraft position.
+/// \param values A double array with the information for the terrain output. The format of values is
+///               [Lat, Lon, Alt, Nx, Ny, Nz, Vx, Vy, Vz, wet, result]. The first three are for output of
+///               the Lat and Lon of the aircraft with the terrain height directly below. The next three
+///               represent the terrain normal. The next three represent the velocity of the terrain.
+///               The wet variable is 0.0 if the terrain is dry and 1.0 if wet.
+///               The last output is the terrain probe result parameter.
+/// \param ac     The aircraft number to get the terrain data of. 0 for the main/user's aircraft.
+/// \returns      0 if successful, otherwise a negative value.
+int getTERR(XPCSocket sock, double posi[3], double values[11], char ac);
 
 // Controls
 

--- a/C/src/xplaneConnect.h
+++ b/C/src/xplaneConnect.h
@@ -234,6 +234,23 @@ int sendPOSI(XPCSocket sock, double values[], int size, char ac);
 /// \returns      0 if successful, otherwise a negative value.
 int getTERR(XPCSocket sock, double posi[3], double values[11], char ac);
 
+/// Sets the position and orientation and gets the terrain information of the specified aircraft.
+///
+/// \param sock   The socket to use to send the command.
+/// \param posi   A double array representing position data about the aircraft. The format of values is
+///               [Lat, Lon, Alt, Pitch, Roll, Yaw, Gear]. If less than 7 values are specified,
+///               the unspecified values will be left unchanged.
+/// \param size   The number of elements in posi.
+/// \param values A double array with the information for the terrain output. The format of values is
+///               [Lat, Lon, Alt, Nx, Ny, Nz, Vx, Vy, Vz, wet, result]. The first three are for output of
+///               the Lat and Lon of the aircraft with the terrain height directly below. The next three
+///               represent the terrain normal. The next three represent the velocity of the terrain.
+///               The wet variable is 0.0 if the terrain is dry and 1.0 if wet.
+///               The last output is the terrain probe result parameter.
+/// \param ac     The aircraft number to set the position of. 0 for the main/user's aircraft.
+/// \returns      0 if successful, otherwise a negative value.
+int sendPOST(XPCSocket sock, double posi[], int size, double values[11], char ac);
+
 // Controls
 
 /// Gets the control surface information for the specified aircraft.

--- a/xpcPlugin/Message.cpp
+++ b/xpcPlugin/Message.cpp
@@ -138,7 +138,7 @@ namespace XPC
 				cur += 1 + buffer[cur];
 			}
 		}
-		else if (head == "POSI")
+		else if (head == "POSI" || head == "POST")
 		{
 			char aircraft = buffer[5];
 			float gear;

--- a/xpcPlugin/MessageHandlers.cpp
+++ b/xpcPlugin/MessageHandlers.cpp
@@ -70,6 +70,7 @@ namespace XPC
 			handlers.insert(std::make_pair("GETC", MessageHandlers::HandleGetC));
 			handlers.insert(std::make_pair("GETP", MessageHandlers::HandleGetP));
 			handlers.insert(std::make_pair("GETT", MessageHandlers::HandleGetT));
+			handlers.insert(std::make_pair("POST", MessageHandlers::HandlePosT));
 			// X-Plane data messages
 			handlers.insert(std::make_pair("DSEL", MessageHandlers::HandleXPlaneData));
 			handlers.insert(std::make_pair("USEL", MessageHandlers::HandleXPlaneData));
@@ -628,6 +629,21 @@ namespace XPC
 				DataManager::Set(DREF_PauseAI, ai, 0, 20);
 			}
 		}
+	}
+
+	void MessageHandlers::HandlePosT(const Message& msg)
+	{
+		MessageHandlers::HandlePosi(msg);
+		
+		const unsigned char* buffer = msg.GetBuffer();
+		char aircraftNumber = buffer[5];
+		Log::FormatLine(LOG_TRACE, "POST", "Getting terrain information for aircraft %u", aircraftNumber);
+		
+		double pos[3];
+		pos[0] = DataManager::GetDouble(DREF_Latitude, aircraftNumber);
+		pos[1] = DataManager::GetDouble(DREF_Longitude, aircraftNumber);
+		pos[2] = 0.0;
+		MessageHandlers::SendTerr(pos, aircraftNumber);
 	}
 
 	void MessageHandlers::HandleGetT(const Message& msg)

--- a/xpcPlugin/MessageHandlers.cpp
+++ b/xpcPlugin/MessageHandlers.cpp
@@ -63,6 +63,7 @@ namespace XPC
 			handlers.insert(std::make_pair("DREF", MessageHandlers::HandleDref));
 			handlers.insert(std::make_pair("GETD", MessageHandlers::HandleGetD));
 			handlers.insert(std::make_pair("POSI", MessageHandlers::HandlePosi));
+			handlers.insert(std::make_pair("POST", MessageHandlers::HandlePosT));
 			handlers.insert(std::make_pair("SIMU", MessageHandlers::HandleSimu));
 			handlers.insert(std::make_pair("TEXT", MessageHandlers::HandleText));
 			handlers.insert(std::make_pair("WYPT", MessageHandlers::HandleWypt));
@@ -70,7 +71,6 @@ namespace XPC
 			handlers.insert(std::make_pair("GETC", MessageHandlers::HandleGetC));
 			handlers.insert(std::make_pair("GETP", MessageHandlers::HandleGetP));
 			handlers.insert(std::make_pair("GETT", MessageHandlers::HandleGetT));
-			handlers.insert(std::make_pair("POST", MessageHandlers::HandlePosT));
 			// X-Plane data messages
 			handlers.insert(std::make_pair("DSEL", MessageHandlers::HandleXPlaneData));
 			handlers.insert(std::make_pair("USEL", MessageHandlers::HandleXPlaneData));

--- a/xpcPlugin/MessageHandlers.h
+++ b/xpcPlugin/MessageHandlers.h
@@ -76,6 +76,7 @@ namespace XPC
 		static void HandleWypt(const Message& msg);
 		static void HandleView(const Message& msg);
 		static void HandleGetT(const Message& msg);
+		static void HandlePosT(const Message& msg);
 
 		static void HandleXPlaneData(const Message& msg);
 		static void HandleUnknown(const Message& msg);

--- a/xpcPlugin/MessageHandlers.h
+++ b/xpcPlugin/MessageHandlers.h
@@ -70,13 +70,13 @@ namespace XPC
 		static void HandleGetC(const Message& msg);
 		static void HandleGetD(const Message& msg);
 		static void HandleGetP(const Message& msg);
+		static void HandleGetT(const Message& msg);
 		static void HandlePosi(const Message& msg);
+		static void HandlePosT(const Message& msg);
 		static void HandleSimu(const Message& msg);
 		static void HandleText(const Message& msg);
 		static void HandleWypt(const Message& msg);
 		static void HandleView(const Message& msg);
-		static void HandleGetT(const Message& msg);
-		static void HandlePosT(const Message& msg);
 
 		static void HandleXPlaneData(const Message& msg);
 		static void HandleUnknown(const Message& msg);


### PR DESCRIPTION
In simulation environments using X-Plane as a visual system, the user will need to use sendPOSI to move the aircraft in X-Plane, but will also need to use getTERR to return the height of the terrain below the aircraft for landing gear reaction modeling.  It is very useful to be able to do this in one step, so have created the sendPOST function that combines sendPOSI with getTERR.  sendPOST sends a POST UDP message, which has exactly the same format as the POSI UDP message, just with a POST header.  The plugin has been modified to interpret this message, position the airplane in the same way as sendPOSI, and then return a TERR UDP message.  sendPOST then reads the TERR message and provides the terrain information to the user.