### PR TITLE
  Minimize Send and Receive Socket Timeout Delays

### DIFF
--- a/C/src/xplaneConnect.c
+++ b/C/src/xplaneConnect.c
@@ -195,9 +195,9 @@ int readUDP(XPCSocket sock, char buffer[], int len)
 	// Without this, playback may become choppy due to process blocking
 
 	// Definitions
-	FD_SET stReadFDS;
-	FD_SET stExceptFDS;
-	struct timeval tv;
+	fd_set stReadFDS;
+	fd_set stExceptFDS;
+	struct timeval timeout;
 
 	// Setup for Select
 	FD_ZERO(&stReadFDS);
@@ -207,11 +207,11 @@ int readUDP(XPCSocket sock, char buffer[], int len)
 
 	// Set timeout period for select to 0.05 sec = 50 milliseconds = 50,000 microseconds (0 makes it polling)
 	// TO DO - This could be set to 0 if a message handling system were implemented, like in the plugin.
-	tv.tv_sec = 0;
-	tv.tv_usec = 50000;
+	timeout.tv_sec = 0;
+	timeout.tv_usec = 50000;
 
 	// Select Command
-	int status = select(-1, &stReadFDS, (FD_SET*)0, &stExceptFDS, &tv);
+	int status = select(sock.sock+1, &stReadFDS, NULL, &stExceptFDS, &timeout);
 	if (status < 0)
 	{
 		printError("readUDP", "Select command error");

--- a/xpcPlugin/UDPSocket.cpp
+++ b/xpcPlugin/UDPSocket.cpp
@@ -121,7 +121,7 @@ namespace XPC
 #endif
 			return -1;
 		}
-		if (result == 0)
+		if (status == 0)
 		{
 			// No data
 			return -1;

--- a/xpcPlugin/UDPSocket.cpp
+++ b/xpcPlugin/UDPSocket.cpp
@@ -110,7 +110,7 @@ namespace XPC
 		tv.tv_usec = 0;
 
 		// Select Command
-		int status = select(-1, &stReadFDS, (FD_SET *)0, &stExceptFDS, &tv);
+		int status = select(-1, &stReadFDS, (FD_SET*)0, &stExceptFDS, &tv);
 		if (status < 0)
 		{
 #ifdef _WIN32

--- a/xpcPlugin/UDPSocket.cpp
+++ b/xpcPlugin/UDPSocket.cpp
@@ -95,9 +95,9 @@ namespace XPC
 		// Without this, playback may become choppy due to process blocking
 
 		// Definitions
-		FD_SET stReadFDS;
-		FD_SET stExceptFDS;
-		timeval tv;
+		fd_set stReadFDS;
+		fd_set stExceptFDS;
+		struct timeval timeout;
 
 		// Setup for Select
 		FD_ZERO(&stReadFDS);
@@ -106,11 +106,11 @@ namespace XPC
 		FD_SET(sock, &stExceptFDS);
 
 		// Set timeout period for select to 0 to poll the socket
-		tv.tv_sec = 0;
-		tv.tv_usec = 0;
+		timeout.tv_sec = 0;
+		timeout.tv_usec = 0;
 
 		// Select Command
-		int status = select(-1, &stReadFDS, (FD_SET*)0, &stExceptFDS, &tv);
+		int status = select(sock+1, &stReadFDS, NULL, &stExceptFDS, &timeout);
 		if (status < 0)
 		{
 #ifdef _WIN32

--- a/xpcPlugin/UDPSocket.h
+++ b/xpcPlugin/UDPSocket.h
@@ -13,8 +13,9 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <sys/time.h>
+#include <sys/types.h>
 #include <unistd.h>
-#include <sys/select.h>
 #endif
 
 

--- a/xpcPlugin/UDPSocket.h
+++ b/xpcPlugin/UDPSocket.h
@@ -14,6 +14,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <unistd.h>
+#include <sys/select.h>
 #endif
 
 


### PR DESCRIPTION
In the xplaneConnect.c sendUDP and readUDP functions, longer than necessary socket timeouts were being used.  They were also different for Windows and Linux/Mac.  These socket timeouts contribute to process time delay and potential stuttering.  The timeouts are now minimized based on testing with the Example and Test programs.  They are also standardized for all operating systems.

Line 209 of xplaneConnect.c has a TO DO comment for a potential future upgrade.  If the xplaneConnect.c functions had message handlers like the plugin, then the socket timeout of the readUDP function could be set to 0 to make the read polling.  The process would not need to wait around for a read to complete.  It could move on to other tasks and read and process the UDP messages as they arrive.

In the plugin UDPSocket.cpp code, SendTo and Read were using longer than necessary socket timeouts with the same potential result as for xplaneConnect.  They were also using different values between Window and Linux/Mac.  The timeouts are now standardized for all operating systems and coded in the same manner as the xplaneConnect.c functions.  Note that here, the Read select timeout is set to 0 in order to make the Read polling.  We can do this here because of the message handling that is done in the plugin.