### PR TITLE
python3 integer division issue

### DIFF
--- a/Python3/src/xpc.py
+++ b/Python3/src/xpc.py
@@ -120,7 +120,7 @@ class XPlaneConnect(object):
         buffer = self.readUDP()
         if len(buffer) < 6:
             return None
-        rows = (len(buffer) - 5) / 36
+        rows = (len(buffer) - 5) // 36
         data = []
         for i in range(rows):
             data.append(struct.unpack_from(b"9f", buffer, 5 + 36*i))


### PR DESCRIPTION
`readDATA` method uses `range` which requires the argument to be an integer (`'float' object cannot be interpreted as an integer`). `rows` is calculated by dividing the length of the buffer -5 by 36. Division in python 3 returns a float. By using integer division (`//` instead of `/`), the `rows` variable will be an int which will not cause this exception.