### PR TITLE
Added BCOM/ECOM commands to enable support of beginning/ending X-Plane commands

### DIFF
--- a/xpcPlugin/DataManager.cpp
+++ b/xpcPlugin/DataManager.cpp
@@ -34,6 +34,7 @@ namespace XPC
 	static map<DREF, XPLMDataRef> drefs;
 	static map<DREF, XPLMDataRef> mdrefs[PLANE_COUNT];
 	static map<string, XPLMDataRef> sdrefs;
+	static map<XPLMCommandRef, bool> commandStarted;
 
 	DREF XPData[134][8] = { DREF_None };
 
@@ -792,19 +793,59 @@ namespace XPC
 		Set(DREF_FlapActual, value);
 	}
 
-	void DataManager::Execute(const std::string& comm)
+	void DataManager::MomentaryCommand(const std::string& comm)
 	{
-		Log::FormatLine(LOG_INFO, "DMAN", "Executing command (value:%s)", comm.c_str());
+		Log::FormatLine(LOG_INFO, "DMAN", "Executing momentary command (value:%s)", comm.c_str());
 
  		XPLMCommandRef xcref = XPLMFindCommand(comm.c_str());
 		if (!xcref)
 		{
 			// COMM does not exist
-			Log::FormatLine(LOG_ERROR, "DMAN", "ERROR: invalid COMM %s", comm.c_str());
+			Log::FormatLine(LOG_ERROR, "DMAN", "ERROR: invalid command %s", comm.c_str());
 			return;
 		}
 
  		XPLMCommandOnce(xcref);
+	}
+
+	void DataManager::BeginCommand(const std::string& comm)
+	{
+		Log::FormatLine(LOG_INFO, "DMAN", "Starting command (value:%s)", comm.c_str());
+
+		XPLMCommandRef xcref = XPLMFindCommand(comm.c_str());
+		if (!xcref)
+		{
+			// Command does not exist
+			Log::FormatLine(LOG_ERROR, "DMAN", "ERROR: invalid command %s", comm.c_str());
+			return;
+		}
+
+		// Flag the command as having been explicitly started by the plugin
+		commandStarted[xcref] = true;
+		XPLMCommandBegin(xcref);
+	}
+
+	void DataManager::EndCommand(const std::string& comm)
+	{
+		Log::FormatLine(LOG_INFO, "DMAN", "Ending command (value:%s)", comm.c_str());
+
+		XPLMCommandRef xcref = XPLMFindCommand(comm.c_str());
+		if (!xcref)
+		{
+			// Command does not exist
+			Log::FormatLine(LOG_ERROR, "DMAN", "ERROR: invalid command %s", comm.c_str());
+			return;
+		}
+
+		// If the command had not been explicitly started by the plugin, do not send a command to X-Plane to end it -
+		// this is not allowed per the X-Plane SDK documentation
+		if (commandStarted.find(xcref) == commandStarted.end() || commandStarted[xcref] == false)
+		{
+			Log::FormatLine(LOG_ERROR, "DMAN", "ERROR: Attempted to end command %s that had not been explicitly started.", comm.c_str());
+		}
+
+		commandStarted[xcref] = false;
+		XPLMCommandEnd(xcref);
 	}
 
 	float DataManager::GetDefaultValue()

--- a/xpcPlugin/DataManager.h
+++ b/xpcPlugin/DataManager.h
@@ -415,7 +415,7 @@ namespace XPC
  		/// \param comm   The name of the command to momentarily execute.
 		/// 
 		/// \remarks This is the equivalent of calling BeginCommand() and EndCommand() back to back.
- 		static void MomentaryCommand(const std::string& comm);
+ 		static void ExecuteMomentaryCommand(const std::string& comm);
 
 		/// Starts the execution of a command. The command is "held down" until it is explicitly ended by EndCommand().
 		///

--- a/xpcPlugin/DataManager.h
+++ b/xpcPlugin/DataManager.h
@@ -410,10 +410,26 @@ namespace XPC
 		/// \param value The flaps settings. Should be between 0.0 (no flaps) and 1.0 (full flaps).
 		static void SetFlaps(float value);
 
-		/// Executes a command
+		/// Executes a momentary command (begins and ends immediately).
  		///
- 		/// \param comm   The name of the command to execute.
- 		static void Execute(const std::string& comm);
+ 		/// \param comm   The name of the command to momentarily execute.
+		/// 
+		/// \remarks This is the equivalent of calling BeginCommand() and EndCommand() back to back.
+ 		static void MomentaryCommand(const std::string& comm);
+
+		/// Starts the execution of a command. The command is "held down" until it is explicitly ended by EndCommand().
+		///
+		/// \param comm   The name of the command to begin.
+		/// 
+		/// \remarks Each BeginCommand call must be balanced with an associated EndCommand call.
+		static void BeginCommand(const std::string& comm);
+
+		/// Ends the execution of a command started with BeginCommand().
+		///
+		/// \param comm   The name of the command to end.
+		/// 
+		/// \remarks The EndCommand call must not be issued for a command that was not explicitly begun.
+		static void EndCommand(const std::string& comm);
 
 		/// Gets a default value that indicates that a dataref should not be changed.
 		static float GetDefaultValue();

--- a/xpcPlugin/MessageHandlers.cpp
+++ b/xpcPlugin/MessageHandlers.cpp
@@ -72,6 +72,8 @@ namespace XPC
 			handlers.insert(std::make_pair("GETP", MessageHandlers::HandleGetP));
 			handlers.insert(std::make_pair("COMM", MessageHandlers::HandleComm));
 			handlers.insert(std::make_pair("GETT", MessageHandlers::HandleGetT));
+			handlers.insert(std::make_pair("BCOM", MessageHandlers::HandleBCom));
+			handlers.insert(std::make_pair("ECOM", MessageHandlers::HandleECom));
 			// X-Plane data messages
 			handlers.insert(std::make_pair("DSEL", MessageHandlers::HandleXPlaneData));
 			handlers.insert(std::make_pair("USEL", MessageHandlers::HandleXPlaneData));
@@ -933,7 +935,7 @@ namespace XPC
  			std::string comm = std::string((char*)buffer + pos, len);
  			pos += len;
 
-  			DataManager::Execute(comm);
+  			DataManager::MomentaryCommand(comm);
  			Log::FormatLine(LOG_DEBUG, "COMM", "Execute command %s", comm.c_str());
  		}
  		if (pos != size)
@@ -941,6 +943,56 @@ namespace XPC
  			Log::WriteLine(LOG_ERROR, "COMM", "ERROR: Command did not terminate at the expected position.");
  		}
  	}
+
+	void MessageHandlers::HandleBCom(const Message& msg)
+	{
+		Log::FormatLine(LOG_TRACE, "BCOM", "Request to execute BCOM command received (Conn %i)", connection.id);
+		const unsigned char* buffer = msg.GetBuffer();
+		std::size_t size = msg.GetSize();
+		std::size_t pos = 5;
+		while (pos < size)
+		{
+			unsigned char len = buffer[pos++];
+			if (pos + len > size)
+			{
+				break;
+			}
+			std::string comm = std::string((char*)buffer + pos, len);
+			pos += len;
+
+			DataManager::BeginCommand(comm);
+			Log::FormatLine(LOG_DEBUG, "COMM", "Execute command %s", comm.c_str());
+		}
+		if (pos != size)
+		{
+			Log::WriteLine(LOG_ERROR, "COMM", "ERROR: Command did not terminate at the expected position.");
+		}
+	}
+
+	void MessageHandlers::HandleECom(const Message& msg)
+	{
+		Log::FormatLine(LOG_TRACE, "ECOM", "Request to execute ECOM command received (Conn %i)", connection.id);
+		const unsigned char* buffer = msg.GetBuffer();
+		std::size_t size = msg.GetSize();
+		std::size_t pos = 5;
+		while (pos < size)
+		{
+			unsigned char len = buffer[pos++];
+			if (pos + len > size)
+			{
+				break;
+			}
+			std::string comm = std::string((char*)buffer + pos, len);
+			pos += len;
+
+			DataManager::EndCommand(comm);
+			Log::FormatLine(LOG_DEBUG, "COMM", "Execute command %s", comm.c_str());
+		}
+		if (pos != size)
+		{
+			Log::WriteLine(LOG_ERROR, "COMM", "ERROR: Command did not terminate at the expected position.");
+		}
+	}
 
 	void MessageHandlers::HandleWypt(const Message& msg)
 	{

--- a/xpcPlugin/MessageHandlers.cpp
+++ b/xpcPlugin/MessageHandlers.cpp
@@ -936,7 +936,7 @@ namespace XPC
  			pos += len;
 
   			DataManager::MomentaryCommand(comm);
- 			Log::FormatLine(LOG_DEBUG, "COMM", "Execute command %s", comm.c_str());
+ 			Log::FormatLine(LOG_DEBUG, "COMM", "Execute momentary command %s", comm.c_str());
  		}
  		if (pos != size)
  		{
@@ -961,11 +961,11 @@ namespace XPC
 			pos += len;
 
 			DataManager::BeginCommand(comm);
-			Log::FormatLine(LOG_DEBUG, "COMM", "Execute command %s", comm.c_str());
+			Log::FormatLine(LOG_DEBUG, "BCOM", "Begin command %s", comm.c_str());
 		}
 		if (pos != size)
 		{
-			Log::WriteLine(LOG_ERROR, "COMM", "ERROR: Command did not terminate at the expected position.");
+			Log::WriteLine(LOG_ERROR, "BCOM", "ERROR: Command did not terminate at the expected position.");
 		}
 	}
 
@@ -986,11 +986,11 @@ namespace XPC
 			pos += len;
 
 			DataManager::EndCommand(comm);
-			Log::FormatLine(LOG_DEBUG, "COMM", "Execute command %s", comm.c_str());
+			Log::FormatLine(LOG_DEBUG, "ECOM", "End command %s", comm.c_str());
 		}
 		if (pos != size)
 		{
-			Log::WriteLine(LOG_ERROR, "COMM", "ERROR: Command did not terminate at the expected position.");
+			Log::WriteLine(LOG_ERROR, "ECOM", "ERROR: Command did not terminate at the expected position.");
 		}
 	}
 

--- a/xpcPlugin/MessageHandlers.cpp
+++ b/xpcPlugin/MessageHandlers.cpp
@@ -935,7 +935,7 @@ namespace XPC
  			std::string comm = std::string((char*)buffer + pos, len);
  			pos += len;
 
-  			DataManager::MomentaryCommand(comm);
+  			DataManager::ExecuteMomentaryCommand(comm);
  			Log::FormatLine(LOG_DEBUG, "COMM", "Execute momentary command %s", comm.c_str());
  		}
  		if (pos != size)

--- a/xpcPlugin/MessageHandlers.h
+++ b/xpcPlugin/MessageHandlers.h
@@ -78,6 +78,8 @@ namespace XPC
 		static void HandleWypt(const Message& msg);
 		static void HandleView(const Message& msg);
 		static void HandleComm(const Message& msg);
+		static void HandleBCom(const Message& msg);
+		static void HandleECom(const Message& msg);
 
 		static void HandleXPlaneData(const Message& msg);
 		static void HandleUnknown(const Message& msg);


### PR DESCRIPTION
I added two new commands to the plugin: **BCOM** (begin command) and **ECOM** (end command). These take the same data format as the existing COMM command. These call the X-Plane SDK's `XPLMCommandBegin` and `XPLMCommandEnd` functions respectively, which allow you to independently trigger and end a command (allowing you to "hold down a button"). 

The data manager also explicitly tracks commands sent to X-Plane to ensure that only commands that have been explicitly started by `XPLMCommandBegin` can be ended by `XPLMCommandEnd` (a requirement of the X-Plane SDK). I also renamed `DataManager::Execute()` to `DataManager::MomentaryCommand()` for clarity and consistency with `DataManager::BeginCommand()` and `DataManager::EndCommand()`.