### PR TITLE
Fix Issue #198

### DIFF
--- a/Python3/src/xpc.py
+++ b/Python3/src/xpc.py
@@ -310,10 +310,10 @@ class XPlaneConnect(object):
                 if len(value) > 255:
                     raise ValueError("value must have less than 256 items.")
                 fmt = "<B{0:d}sB{1:d}f".format(len(dref), len(value))
-                buffer += struct.pack(fmt.encode(), len(dref), dref.encode(), len(value), value)
+                buffer += struct.pack(fmt.encode(), len(dref), dref.encode(), len(value), *value)
             else:
                 fmt = "<B{0:d}sBf".format(len(dref))
-                buffer += struct.pack(fmt.encode(), len(dref), dref.encode(), 1, value)
+                buffer += struct.pack(fmt.encode(), len(dref), dref.encode(), 1, *value)
 
         # Send
         self.sendUDP(buffer)


### PR DESCRIPTION
Addresses issue #198, where the Python3 version fails when using sendDREF / sendDREFs for a dataref that requires multiple values. Issue is that the array of dataref values is passed directly into the pack function instead of passing each array element as a separate argument. Solution due to jamesdunham in the issue comments.