### PR TITLE
[Build] CameraCallbacks.cpp is missing in CMakeLists.txt

### DIFF
--- a/xpcPlugin/CMakeLists.txt
+++ b/xpcPlugin/CMakeLists.txt
@@ -16,6 +16,7 @@ SET(XPC_OUTPUT_DIR "XPlaneConnect")
 SET(XPC_OUTPUT_NAME "lin")
 
 add_library(xpc64 SHARED XPCPlugin.cpp
+	CameraCallbacks.cpp
 	DataManager.cpp
 	Drawing.cpp
 	Log.cpp
@@ -29,6 +30,7 @@ set_target_properties(xpc64 PROPERTIES OUTPUT_NAME ${XPC_OUTPUT_NAME})
 set_target_properties(xpc64 PROPERTIES COMPILE_FLAGS "-m64 -fno-stack-protector" LINK_FLAGS "-shared -rdynamic -nodefaultlibs -undefined_warning -m64 -fno-stack-protector")
 
 add_library(xpc32 SHARED XPCPlugin.cpp
+	CameraCallbacks.cpp
 	DataManager.cpp
 	Drawing.cpp
 	Log.cpp


### PR DESCRIPTION
The file `CameraCallbacks.cpp` is missing in the `CMakeLists.txt` and the generated binary on Linux has an undefined symbol (the release file is also affected).

This is (probably) the same problem that caused this issue: #239