### PR TITLE
GETD check remaining buffer size before adding data

### DIFF
--- a/xpcPlugin/MessageHandlers.cpp
+++ b/xpcPlugin/MessageHandlers.cpp
@@ -540,6 +540,12 @@ namespace XPC
 		{
 			float values[255];
 			int count = DataManager::Get(connection.getdRequest[i], values, 255);
+			if ((cur + count * sizeof(float) + 1) > 4095)
+			{
+				Log::FormatLine(LOG_ERROR, "GETD", "ERROR: Too many data requested for connection %i.",
+					connection.id);
+				return;
+			}
 			response[cur++] = count;
 			memcpy(response + cur, values, count * sizeof(float));
 			cur += count * sizeof(float);


### PR DESCRIPTION
### Summary
This pull request addresses #226 

It adds a check to `MessageHandlers::HandleGetD`, ensuring no data will be added to the response buffer if the remaining space in the buffer is not sufficient to accept the data. As described in #226, this can lead to a segmentation fault, resulting in a CTD of X-Plane itself.

### Consequences:
The current fix leaves the request unanswered (no message being sent), so the connection will time out on client side.

### Alternate Solutions:
1. Instead of aborting, send an incomplete result (use `break` instead of `return` in line 547).
2. Instead of aborting, send a dedicated message, indicating that too many data were requested.

#### Advantages of alternate solutions
Client receives at least some data (1) or clear information why the request failed (2)

#### Disadvantages of alternate solutions
Requires modification of all client libraries to
* check the response actually contained the number of data refs indicated in byte 5 (1)
* interpret the response when an error message is submitted

### Conclusion
The current fix is not perfect, but prevents the simulator from crashing, and doesn't require modification of the client libraries.