### PR TITLE
avoid crash due to message overflow via data truncation, adds message limit #defines, increases default buffer size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ ipch/
 *.user
 *.sdf
 *.sbr
+.vs/
 
 # XCode Files #
 ###############

--- a/xpcPlugin/DataManager.cpp
+++ b/xpcPlugin/DataManager.cpp
@@ -35,7 +35,7 @@ namespace XPC
 	static map<DREF, XPLMDataRef> mdrefs[PLANE_COUNT];
 	static map<string, XPLMDataRef> sdrefs;
 
-	DREF XPData[134][8] = { DREF_None };
+	DREF XPData[XPC_MAX_COLS][8] = { DREF_None };
 
 	void DataManager::Initialize()
 	{
@@ -357,7 +357,7 @@ namespace XPC
 		}
 		if ((dataType & 16) == 16) // Integer array
 		{
-			const std::size_t TMP_SIZE = 200;
+			const std::size_t TMP_SIZE = XPC_MAX_DREF_VALUES;
 			int iValues[TMP_SIZE];
 			int drefSize = XPLMGetDatavi(xdref, NULL, 0, 0);
 			if (drefSize > size)
@@ -382,7 +382,7 @@ namespace XPC
 		}
 		if ((dataType & 32) == 32) // Byte array
 		{
-			const std::size_t TMP_SIZE = 1024;
+			const std::size_t TMP_SIZE = XPC_MAX_DREF_VALUES;
 			char bValues[TMP_SIZE];
 			int drefSize = XPLMGetDatab(xdref, NULL, 0, 0);
 			if (drefSize > size)
@@ -561,7 +561,7 @@ namespace XPC
 		}
 		else if ((dataType & 16) == 16) // Integer Array
 		{
-			const std::size_t TMP_SIZE = 200;
+			const std::size_t TMP_SIZE = XPC_MAX_DREF_VALUES;
 			int iValues[TMP_SIZE];
 			int drefSize = XPLMGetDatavi(xdref, NULL, 0, 0);
 			if (size > drefSize)
@@ -587,7 +587,7 @@ namespace XPC
 		}
 		else if ((dataType & 32) == 32) // Byte Array
 		{
-			const std::size_t TMP_SIZE = 1024;
+			const std::size_t TMP_SIZE = XPC_MAX_DREF_VALUES;
 			char bValues[TMP_SIZE];
 			int drefSize = XPLMGetDatab(xdref, NULL, 0, 0);
 			if (size > drefSize)

--- a/xpcPlugin/DataManager.h
+++ b/xpcPlugin/DataManager.h
@@ -4,6 +4,7 @@
 #define XPCPLUGIN_DATAMANAGER_H_
 
 #include <string>
+#include "XPCLimits.h"
 
 namespace XPC
 {
@@ -137,7 +138,7 @@ namespace XPC
 	};
 
 	/// Maps X-Plane dataref lines to XPC DREF values.
-	extern DREF XPData[134][8];
+	extern DREF XPData[XPC_MAX_COLS][8];
 
 	/// Contains methods to martial data between the plugin and X-Plane.
 	///

--- a/xpcPlugin/Message.h
+++ b/xpcPlugin/Message.h
@@ -4,6 +4,7 @@
 #define XPCPLUGIN_MESSAGE_H_
 
 #include "UDPSocket.h"
+#include "XPCLimits.h"
 
 namespace XPC
 {
@@ -44,7 +45,7 @@ namespace XPC
 	private:
 		Message();
 
-		static const std::size_t bufferSize = 4096;
+		static const std::size_t bufferSize = XPC_MAX_MESSAGE_SIZE;
 		unsigned char buffer[bufferSize];
 		std::size_t size;
 		struct sockaddr source;

--- a/xpcPlugin/MessageHandlers.h
+++ b/xpcPlugin/MessageHandlers.h
@@ -96,7 +96,7 @@ namespace XPC
 			unsigned char id;
 			sockaddr addr;
 			unsigned char getdCount;
-			std::string getdRequest[255];
+			std::string getdRequest[XPC_MAX_DREF_COUNT];
 		} ConnectionInfo;
 
 		static std::map<std::string, ConnectionInfo> connections;

--- a/xpcPlugin/XPCLimits.h
+++ b/xpcPlugin/XPCLimits.h
@@ -1,0 +1,4 @@
+#define XPC_MAX_MESSAGE_SIZE	16384	// Max message size in Message.h; was 4096
+#define XPC_MAX_DREF_VALUES		  255 	// Max dref elements, must fit in single byte
+#define XPC_MAX_DREF_COUNT		  255   // Max number of drefs requested per message, encoded as single byte
+#define XPC_MAX_COLS 			  134 	// Max number of columns in	data array, MessageHandlers


### PR DESCRIPTION
*Summary*

This pull request addresses [issue 226](https://github.com/nasa/XPlaneConnect/issues/226) where requesting too many datarefs and/or datarefs with large numbers of values could overflow the fixed message buffer of 4096 bytes and cause XPlane to crash to the desktop.

This PR extends the idea in [PR266](https://github.com/nasa/XPlaneConnect/pull/266/files) but rather than simply aborting the message response completely, a dataref that would overflow the buffer is replaced with an empty list (a value count of 0 and no data), allowing a valid response to the client.  In those cases, the client will see an empty list for the offending dataref(s) rather than the expected dataref content, and an error message will be logged in `XPCLog.txt` like:

    15:05:37.852|ERROR|GETD|ERROR: omitting data (1020 bytes) for dref 243 to avoid exceeding message buffer for connection 1.

This PR also increases the default message buffer from 4096 to 16384 bytes (which is still safe for a UDP packet, and the max message size requested by the Python client), and replaces several other numeric constants repeated throughout the code with #define'd constant values via `XPCLimits.h`

*Testing*

Tested via python client by requesting all 4600+ datarefs listed in `Resources/plugins/DataRefs.txt` in blocks of 250.  No segfault was observed, and drefs that previously would have overflowed are successfully parsed as an empty list by the Python client, with expected error messages logged in `XPCLog.txt`.