### PR TITLE
Bugfix: Add a cleanup command to closeUDP() (C/C++)

### DIFF
--- a/C/src/xplaneConnect.c
+++ b/C/src/xplaneConnect.c
@@ -139,6 +139,7 @@ void closeUDP(XPCSocket sock)
 {
 #ifdef _WIN32
 	int result = closesocket(sock.sock);
+	WSACleanup();
 #else
 	int result = close(sock.sock);
 #endif

--- a/xpcPlugin/UDPSocket.cpp
+++ b/xpcPlugin/UDPSocket.cpp
@@ -82,6 +82,7 @@ namespace XPC
 		Log::FormatLine(LOG_TRACE, tag, "Closing socket (%d)", this->sock);
 #ifdef _WIN32
 		closesocket(this->sock);
+		WSACleanup();
 #elif (__APPLE__ || __linux)
 		close(this->sock);
 #endif


### PR DESCRIPTION
_**Description of the bug:**_
When using the C/C++ version of XPlaneConnect, a loss of packets received would cause a block operation in the socket used by XPlaneConnect. Since this socket would now be unusable, users would expect to close and re-open the socket in order to continue communicating with X-Plane 11. However, if this were done, any subsequent DREFs read would be gibberish despite the simulator running correctly.

This was proven by the fact that if the terminal with the running code was closed, and the code was subsequently re-run, the DREFs would now read normally despite the block having occurred in the previous session.

The potential users affected were those who ran a large number of simulations programmatically in X-Plane 11, such as myself. If a packet loss occurred at any time throughout the simulation, any subsequent runs would not yield valid data. This lead to wasted time and computer resources. Other potential affectees include those people who require to read X-Plane 11 data at a high frequency, such as when using a custom autopilot.

_**Description of the bugfix:**_
Please refer to the [official documentation](https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-wsacleanup) for more details on how `WSACleanup` should be used.

From the official documentation, there must be a call to `WSACleanup` for each successful call to `WSAStartup`. Going through the code (both `xplaneConnect.c` and `xplaneConnect.h`), I did find a call to `WSAStartup` in `aopenUDP`, but I found no calls to `WSACleanup`.

For this reason, following the documentation's guidelines, I decided to add a call to `WSACleanup` within `closeUDP` to clear the data from the block operation and make the socket usable once again.

_**Testing:**_
My testing has not been extensive, but I have not encountered the issue again since I implemented the fix locally. I recommend testing by other users before this PR is merged.