### PR TITLE
Created terrain information functions for Python3 module (getTERR and sendPOST)

### DIFF
--- a/Python3/src/xpc.py
+++ b/Python3/src/xpc.py
@@ -445,6 +445,46 @@ class XPlaneConnect(object):
         # Send
         self.sendUDP(buffer)
 
+    # Terrain
+
+    def getTERR(self, values, ac=0):
+        """Gets terrain information for the specified aircraft.
+
+            Args:
+              values: The position values of the desired terrain location. `values` is a array
+                containing 2 elements. The elements in `values` correspond to the
+                following:
+                  * Latitude (deg)
+                  * Longitude (deg)
+              ac: The aircraft to set the position of. 0 is the main/player aircraft.
+        """
+        # Pack message
+        buffer = struct.pack(b"<4sxB", b"GETT", ac)
+        for i in range(3):
+            val = -998
+            if i < len(values):
+                val = values[i]
+            if i < 3:
+                buffer += struct.pack(b"<d", val)
+            else:
+                buffer += struct.pack(b"<f", val)
+
+        # Send
+        self.sendUDP(buffer)
+
+        # Read response
+        resultBuf = self.readUDP()
+        if len(resultBuf) == 62:
+            result = struct.unpack(b"<4sxBdddfffff",resultBuf[0:50])
+        else:
+            raise ValueError("Unexpected response length.")
+
+        if result[0] != b"TERR":
+            raise ValueError("Unexpected header: " + result[0])
+
+        # Drop the header & ac from the return value
+        return result[2:]
+
 class ViewType(object):
     Forwards = 73
     Down = 74

--- a/Python3/src/xpc.py
+++ b/Python3/src/xpc.py
@@ -456,6 +456,13 @@ class XPlaneConnect(object):
                   * Latitude (deg)
                   * Longitude (deg)
               ac: The aircraft to set the position of. 0 is the main/player aircraft.
+
+            Returns: A 12-element array containing terrain information. The format of the output is
+             [Lat, Lon, Alt, Nx, Ny, Nz, Vx, Vy, Vz, wet result]. The first three are for output of
+             the Lat and Lon of the aircraft with the terrain height directly below. The next three
+             represent the terrain normal. The next three represent the velocity of the terrain.
+             The wet variable is 0.0 if the terrain is dry and 1.0 if wet.
+             The last element is the terrain probe result parameter.
         """
         # Pack message
         buffer = struct.pack(b"<4sxB", b"GETT", ac)
@@ -474,7 +481,7 @@ class XPlaneConnect(object):
         # Read response
         resultBuf = self.readUDP()
         if len(resultBuf) == 62:
-            result = struct.unpack(b"<4sxBdddfffff",resultBuf[0:50])
+            result = struct.unpack(b"<4sxBdddffffffff",resultBuf[0:62])
         else:
             raise ValueError("Unexpected response length.")
 
@@ -489,8 +496,8 @@ class XPlaneConnect(object):
 
             Args:
               values: The position values to set. `values` is a array containing up to
-                7 elements. If less than 7 elements are specified or any elment is set to `-998`,
-                those values will not be changed. The elements in `values` corespond to the
+                7 elements. If less than 7 elements are specified or any element is set to `-998`,
+                those values will not be changed. The elements in `values` correspond to the
                 following:
                   * Latitude (deg)
                   * Longitude (deg)
@@ -500,6 +507,8 @@ class XPlaneConnect(object):
                   * True Heading (deg)
                   * Gear (0=up, 1=down)
               ac: The aircraft to set the position of. 0 is the main/player aircraft.
+
+            Returns: A 12-element array containing terrain information (described in getTERR).
         """
         # Preconditions
         if len(values) < 1 or len(values) > 7:
@@ -524,7 +533,7 @@ class XPlaneConnect(object):
         # Read response
         resultBuf = self.readUDP()
         if len(resultBuf) == 62:
-            result = struct.unpack(b"<4sxBdddfffff",resultBuf[0:50])
+            result = struct.unpack(b"<4sxBdddffffffff",resultBuf[0:62])
         else:
             raise ValueError("Unexpected response length.")
 


### PR DESCRIPTION
I created two new functions (`getTERR` and `sendPOST`) for reading terrain information with the Python3 module. Both functions are based on the functions with the same name for the C module (#204  and #205).

- `getTERR` allows users to read terrain information (lat, lng, elevation, normals (nx, ny, nz), wet/dry, status) by sending a `TERR` UDP message.
- `sendPOST` sets the position of the specified aircraft and returns terrain information by sending a `POST` UDP message (this is a combination of `sendPOSI` and `getTERR`, as explained in #205).
