### PR TITLE
Ported sendCOMM method from py2 to py3

### DIFF
--- a/Python3/src/xpc/__init__.py
+++ b/Python3/src/xpc/__init__.py
@@ -425,6 +425,20 @@ class XPlaneConnect(object):
             buffer = struct.pack(("<4sxBB" + str(len(points)) + "f").encode(), b"WYPT", op, len(points), *points)
         self.sendUDP(buffer)
 
+    def sendCOMM(self, comm):
+        if comm == None:
+            raise ValueError("comm must be non-empty.")
+
+        buffer = struct.pack("<4sx", b"COMM")
+        if len(comm) == 0 or len(comm) > 255:
+            raise ValueError("comm must be a non-empty string less than 256 characters.")
+
+        # Pack message
+        fmt = "<B{0:d}s".format(len(comm))
+        buffer += struct.pack(fmt, len(comm), comm.encode())
+
+        # Send
+        self.sendUDP(buffer)
 
 class ViewType(object):
     Forwards = 73


### PR DESCRIPTION
I needed to be able to send commands from Python and so I looked through some of the older tickets and found that someone had submitted a PR for it, but upon further investigation, it looks like the latest released already includes support for it in the plugin itself, and also in the python2 client, so this PR is simply adding support to the python3 client.

An example that I verified works:
```py
import xpc
with xpc.XPlaneConnect() as client:
    for i in range(20):
        client.sendCOMM('sim/GPS/g430n1_page_dn')
        time.sleep(0.05)
```